### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 A Model Context Protocol (MCP) server that provides seamless integration with Microsoft Graph APIs, enabling AI assistants to interact with Microsoft Teams, users, and organizational data.
 
+<a href="https://glama.ai/mcp/servers/@floriscornel/teams-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@floriscornel/teams-mcp/badge" alt="Teams MCP server" />
+</a>
+
 ## 📦 Installation
 
 To use this MCP server in Cursor/Claude/VS Code, add the following configuration:
@@ -194,7 +198,6 @@ npm run build && node dist/index.js
 - `get_recent_messages` - Get recent messages with advanced filtering options
 - `get_my_mentions` - Find messages mentioning the current user
 
-
 ## 📋 Examples
 
 ### Authentication
@@ -256,4 +259,4 @@ MIT License - see LICENSE file for details
 For issues and questions:
 - Check the existing GitHub issues
 - Review Microsoft Graph API documentation
-- Ensure proper authentication and permissions are configured 
+- Ensure proper authentication and permissions are configured


### PR DESCRIPTION
This PR adds a badge for the [Teams MCP](https://glama.ai/mcp/servers/@floriscornel/teams-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@floriscornel/teams-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@floriscornel/teams-mcp/badge" alt="Teams MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.