### PR TITLE
Fix/secure token cache os keystore

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "@azure/identity": "^4.13.0",
     "@azure/identity-cache-persistence": "^1.2.0",
+    "@azure/msal-node-extensions": "^5.0.6",
     "@microsoft/microsoft-graph-client": "^3.0.7",
     "@microsoft/microsoft-graph-types": "^2.43.1",
     "@modelcontextprotocol/sdk": "^1.27.1",

--- a/src/__tests__/msal-cache.test.ts
+++ b/src/__tests__/msal-cache.test.ts
@@ -82,7 +82,7 @@ describe("MSAL Cache Plugin", () => {
         },
       } as unknown as TokenCacheContext;
 
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
       await cachePlugin.beforeCacheAccess(cacheContext);
 
@@ -106,7 +106,7 @@ describe("MSAL Cache Plugin", () => {
         },
       } as unknown as TokenCacheContext;
 
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
       await cachePlugin.beforeCacheAccess(cacheContext);
 
@@ -169,7 +169,7 @@ describe("MSAL Cache Plugin", () => {
         },
       } as unknown as TokenCacheContext;
 
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
       await cachePlugin.afterCacheAccess(cacheContext);
 

--- a/src/__tests__/msal-cache.test.ts
+++ b/src/__tests__/msal-cache.test.ts
@@ -1,17 +1,49 @@
 import { promises as fs } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import type { TokenCacheContext } from "@azure/msal-node";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const CACHE_PATH = join(homedir(), ".teams-mcp-token-cache.json");
 
 // Mock the filesystem
 vi.mock("node:fs", () => ({
   promises: {
     readFile: vi.fn(),
     writeFile: vi.fn(),
+    unlink: vi.fn(),
   },
 }));
 
-// Import after mocks are set up
-import { CACHE_PATH, cachePlugin } from "../msal-cache.js";
+// Mock msal-node-extensions to use our mocked fs so we can test plugin behavior
+vi.mock("@azure/msal-node-extensions", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@azure/msal-node-extensions")>();
+  const fsMock = await import("node:fs").then((m) => m.promises);
+  const createFileBasedPersistence = (path: string) => ({
+    load: () => (fsMock.readFile as ReturnType<typeof vi.fn>)(path, "utf8"),
+    save: (contents: string) =>
+      (fsMock.writeFile as ReturnType<typeof vi.fn>)(path, contents, "utf8"),
+    delete: vi.fn().mockResolvedValue(undefined),
+  });
+  return {
+    ...actual,
+    KeychainPersistence: {
+      create: (_path: string) => Promise.resolve(createFileBasedPersistence(_path)),
+    },
+    FilePersistenceWithDataProtection: {
+      create: (_path: string) => Promise.resolve(createFileBasedPersistence(_path)),
+    },
+    LibSecretPersistence: {
+      create: (_path: string) => Promise.resolve(createFileBasedPersistence(_path)),
+    },
+    FilePersistence: {
+      create: (path: string) => Promise.resolve(createFileBasedPersistence(path)),
+    },
+  };
+});
+
+// Import after mocks
+import { CACHE_PATH as EXPORTED_CACHE_PATH, createCachePlugin, clearTokenCache } from "../msal-cache.js";
 
 describe("MSAL Cache Plugin", () => {
   beforeEach(() => {
@@ -23,6 +55,7 @@ describe("MSAL Cache Plugin", () => {
       const mockCacheData = '{"test": "data"}';
       vi.mocked(fs.readFile).mockResolvedValue(mockCacheData);
 
+      const cachePlugin = await createCachePlugin();
       const deserializeMock = vi.fn();
       const cacheContext = {
         tokenCache: {
@@ -41,6 +74,7 @@ describe("MSAL Cache Plugin", () => {
       error.code = "ENOENT";
       vi.mocked(fs.readFile).mockRejectedValue(error);
 
+      const cachePlugin = await createCachePlugin();
       const deserializeMock = vi.fn();
       const cacheContext = {
         tokenCache: {
@@ -48,9 +82,7 @@ describe("MSAL Cache Plugin", () => {
         },
       } as unknown as TokenCacheContext;
 
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {
-        // Intentionally empty to suppress console output during tests
-      });
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
       await cachePlugin.beforeCacheAccess(cacheContext);
 
@@ -66,6 +98,7 @@ describe("MSAL Cache Plugin", () => {
       error.code = "EACCES";
       vi.mocked(fs.readFile).mockRejectedValue(error);
 
+      const cachePlugin = await createCachePlugin();
       const deserializeMock = vi.fn();
       const cacheContext = {
         tokenCache: {
@@ -73,15 +106,13 @@ describe("MSAL Cache Plugin", () => {
         },
       } as unknown as TokenCacheContext;
 
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {
-        // Intentionally empty to suppress console output during tests
-      });
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
       await cachePlugin.beforeCacheAccess(cacheContext);
 
       expect(fs.readFile).toHaveBeenCalledWith(CACHE_PATH, "utf8");
       expect(deserializeMock).not.toHaveBeenCalled();
-      expect(consoleErrorSpy).toHaveBeenCalledWith("Warning: Could not read token cache:", error);
+      expect(consoleErrorSpy).toHaveBeenCalled();
 
       consoleErrorSpy.mockRestore();
     });
@@ -92,6 +123,7 @@ describe("MSAL Cache Plugin", () => {
       const mockSerializedData = '{"test": "serialized"}';
       const serializeMock = vi.fn().mockReturnValue(mockSerializedData);
 
+      const cachePlugin = await createCachePlugin();
       const cacheContext = {
         cacheHasChanged: true,
         tokenCache: {
@@ -108,6 +140,7 @@ describe("MSAL Cache Plugin", () => {
     it("should not write cache data when cache has not changed", async () => {
       const serializeMock = vi.fn();
 
+      const cachePlugin = await createCachePlugin();
       const cacheContext = {
         cacheHasChanged: false,
         tokenCache: {
@@ -128,6 +161,7 @@ describe("MSAL Cache Plugin", () => {
       const mockSerializedData = '{"test": "serialized"}';
       const serializeMock = vi.fn().mockReturnValue(mockSerializedData);
 
+      const cachePlugin = await createCachePlugin();
       const cacheContext = {
         cacheHasChanged: true,
         tokenCache: {
@@ -135,15 +169,13 @@ describe("MSAL Cache Plugin", () => {
         },
       } as unknown as TokenCacheContext;
 
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {
-        // Intentionally empty to suppress console output during tests
-      });
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
       await cachePlugin.afterCacheAccess(cacheContext);
 
       expect(serializeMock).toHaveBeenCalled();
       expect(fs.writeFile).toHaveBeenCalledWith(CACHE_PATH, mockSerializedData, "utf8");
-      expect(consoleErrorSpy).toHaveBeenCalledWith("Warning: Could not write token cache:", error);
+      expect(consoleErrorSpy).toHaveBeenCalled();
 
       consoleErrorSpy.mockRestore();
     });
@@ -151,9 +183,15 @@ describe("MSAL Cache Plugin", () => {
 
   describe("CACHE_PATH", () => {
     it("should export CACHE_PATH", () => {
-      expect(CACHE_PATH).toBeDefined();
-      expect(typeof CACHE_PATH).toBe("string");
-      expect(CACHE_PATH).toContain(".teams-mcp-token-cache.json");
+      expect(EXPORTED_CACHE_PATH).toBeDefined();
+      expect(typeof EXPORTED_CACHE_PATH).toBe("string");
+      expect(EXPORTED_CACHE_PATH).toContain(".teams-mcp-token-cache.json");
+    });
+  });
+
+  describe("clearTokenCache", () => {
+    it("should resolve without throwing", async () => {
+      await expect(clearTokenCache()).resolves.toBeUndefined();
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
 } from "@azure/msal-node";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { cachePlugin } from "./msal-cache.js";
+import { createCachePlugin } from "./msal-cache.js";
 import { FULL_SCOPES, GraphService, READ_ONLY_SCOPES } from "./services/graph.js";
 import { registerAuthTools } from "./tools/auth.js";
 import { registerChatTools } from "./tools/chats.js";
@@ -51,13 +51,14 @@ async function authenticate(readOnly: boolean) {
   try {
     console.log("\n📱 Using device code flow...");
 
+    const cachePlugin = await createCachePlugin();
     const msalConfig: Configuration = {
       auth: {
         clientId: CLIENT_ID,
         authority: AUTHORITY,
       },
       cache: {
-        cachePlugin, // Use our custom file-based cache for refresh tokens
+        cachePlugin,
       },
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,12 @@ async function readAuthInfo(): Promise<Record<string, unknown> | undefined> {
     data = await fs.readFile(LEGACY_AUTH_INFO_PATH, "utf8");
     const parsed = JSON.parse(data) as Record<string, unknown>;
     await writeAuthInfoSecure(JSON.stringify(parsed, null, 2));
-    await fs.unlink(LEGACY_AUTH_INFO_PATH).catch(() => {});
+    await fs.unlink(LEGACY_AUTH_INFO_PATH).catch((err) => {
+      console.warn(
+        `Failed to remove legacy auth file ${LEGACY_AUTH_INFO_PATH}: ${err}`
+      );
+      throw err;
+    });
     return parsed;
   } catch {
     return undefined;
@@ -132,7 +137,10 @@ async function authenticate(readOnly: boolean) {
 async function checkAuth() {
   try {
     const authInfo = await readAuthInfo();
-    if (!authInfo?.authenticated || !authInfo?.clientId) return false;
+    if (!authInfo?.authenticated || !authInfo?.clientId) {
+      console.log("❌ No authentication found");
+      return false;
+    }
 
     if (authInfo.authenticated && authInfo.clientId) {
       console.log("✅ Authentication found");
@@ -155,8 +163,9 @@ async function checkAuth() {
       }
 
       // Check if we have expiration info
-      if (authInfo.expiresAt) {
-        const expiresAt = new Date(authInfo.expiresAt);
+      const expiresAtVal = authInfo.expiresAt;
+      if (expiresAtVal != null && (typeof expiresAtVal === "string" || typeof expiresAtVal === "number" || expiresAtVal instanceof Date)) {
+        const expiresAt = new Date(expiresAtVal);
         const now = new Date();
 
         if (expiresAt > now) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,12 @@ import {
 } from "@azure/msal-node";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { createCachePlugin } from "./msal-cache.js";
+import { clearTokenCache, createCachePlugin } from "./msal-cache.js";
+import {
+  deleteAuthInfoSecure,
+  readAuthInfoSecure,
+  writeAuthInfoSecure,
+} from "./secure-storage.js";
 import { FULL_SCOPES, GraphService, READ_ONLY_SCOPES } from "./services/graph.js";
 import { registerAuthTools } from "./tools/auth.js";
 import { registerChatTools } from "./tools/chats.js";
@@ -22,18 +27,31 @@ import { registerUsersTools } from "./tools/users.js";
 const CLIENT_ID = "14d82eec-204b-4c2f-b7e8-296a70dab67e";
 const AUTHORITY = "https://login.microsoftonline.com/common";
 
-const AUTH_INFO_PATH = join(homedir(), ".msgraph-mcp-auth.json");
+// Legacy path for migration from plaintext auth file to secure storage
+const LEGACY_AUTH_INFO_PATH = join(homedir(), ".msgraph-mcp-auth.json");
 
 /** Check whether CLI args contain --read-only. */
 function hasReadOnlyFlag(args: string[]): boolean {
   return args.includes("--read-only");
 }
 
-/** Read the persisted auth info file (best-effort). */
+/** Read auth info from OS secure storage; migrates from legacy plaintext file if present. */
 async function readAuthInfo(): Promise<Record<string, unknown> | undefined> {
+  let data: string | undefined = await readAuthInfoSecure();
+  if (data !== undefined) {
+    try {
+      return JSON.parse(data) as Record<string, unknown>;
+    } catch {
+      return undefined;
+    }
+  }
+  // Migrate from legacy plaintext file
   try {
-    const data = await fs.readFile(AUTH_INFO_PATH, "utf8");
-    return JSON.parse(data) as Record<string, unknown>;
+    data = await fs.readFile(LEGACY_AUTH_INFO_PATH, "utf8");
+    const parsed = JSON.parse(data) as Record<string, unknown>;
+    await writeAuthInfoSecure(JSON.stringify(parsed, null, 2));
+    await fs.unlink(LEGACY_AUTH_INFO_PATH).catch(() => {});
+    return parsed;
   } catch {
     return undefined;
   }
@@ -85,12 +103,12 @@ async function authenticate(readOnly: boolean) {
         grantedScopes: result.scopes,
       };
 
-      await fs.writeFile(AUTH_INFO_PATH, JSON.stringify(authInfo, null, 2));
+      await writeAuthInfoSecure(JSON.stringify(authInfo, null, 2));
 
       console.log("\n✅ Authentication successful!");
       console.log(`👤 Signed in as: ${result.account?.username || "Unknown"}`);
       console.log(`🔒 Mode: ${modeLabel}`);
-      console.log(`💾 Credentials saved to: ${AUTH_INFO_PATH}`);
+      console.log("💾 Credentials saved to OS secure storage (Keychain / Windows Credential Manager / libsecret)");
       console.log("🔄 Refresh token cached for automatic renewal");
       console.log("\n🚀 You can now use the MCP server in Cursor!");
       console.log("   The server will automatically use these credentials.");
@@ -113,8 +131,8 @@ async function authenticate(readOnly: boolean) {
 
 async function checkAuth() {
   try {
-    const data = await fs.readFile(AUTH_INFO_PATH, "utf8");
-    const authInfo = JSON.parse(data);
+    const authInfo = await readAuthInfo();
+    if (!authInfo?.authenticated || !authInfo?.clientId) return false;
 
     if (authInfo.authenticated && authInfo.clientId) {
       console.log("✅ Authentication found");
@@ -162,17 +180,13 @@ async function checkAuth() {
 }
 
 async function logout() {
-  const CACHE_PATH = join(homedir(), ".teams-mcp-token-cache.json");
+  await deleteAuthInfoSecure();
+  await clearTokenCache();
 
+  // Remove legacy plaintext auth file if it still exists
   try {
-    await fs.unlink(AUTH_INFO_PATH);
-  } catch (_error) {
-    // Ignore if file doesn't exist
-  }
-
-  try {
-    await fs.unlink(CACHE_PATH);
-  } catch (_error) {
+    await fs.unlink(LEGACY_AUTH_INFO_PATH);
+  } catch {
     // Ignore if file doesn't exist
   }
 

--- a/src/msal-cache.ts
+++ b/src/msal-cache.ts
@@ -34,10 +34,7 @@ const CACHE_PATH = join(homedir(), ".teams-mcp-token-cache.json");
  *             unencrypted file when libsecret is unavailable.
  */
 /** Creates the OS-native persistence used for the token cache (shared by createCachePlugin and clearTokenCache). */
-async function createCachePersistence(): Promise<
-  Awaited<ReturnType<typeof KeychainPersistence.create>> &
-    { delete: () => Promise<void> }
-> {
+async function createCachePersistence() {
   const platform = process.platform;
 
   if (platform === "darwin") {
@@ -84,6 +81,14 @@ async function createCachePersistence(): Promise<
     }
   }
 
+  const allowPlaintext =
+    process.env.TEAMS_MCP_ALLOW_PLAINTEXT_CACHE === "true";
+  if (!allowPlaintext) {
+    throw new Error(
+      `Secure token storage is not supported on platform "${platform}". ` +
+        `Set TEAMS_MCP_ALLOW_PLAINTEXT_CACHE=true to use an unencrypted file at ${CACHE_PATH} instead.`
+    );
+  }
   console.error(
     `Warning: Secure token storage is not supported on platform "${platform}". ` +
       "Tokens will be stored in an unencrypted file at " +
@@ -97,6 +102,16 @@ export async function createCachePlugin(): Promise<ICachePlugin> {
   return new PersistenceCachePlugin(persistence);
 }
 
+/** True if the error indicates "nothing stored" / "not found" and can be ignored on clear. */
+function isNoCacheToDeleteError(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException).code;
+  const message = err instanceof Error ? err.message : String(err);
+  if (code === "ENOENT") return true;
+  return /not found|no such file|does not exist|no entry|could not find/i.test(
+    message
+  );
+}
+
 /**
  * Clears the token cache from OS-native storage (Keychain, DPAPI, or libsecret).
  * Call this on logout so credentials are fully removed.
@@ -106,7 +121,10 @@ export async function clearTokenCache(): Promise<void> {
     const persistence = await createCachePersistence();
     await persistence.delete();
   } catch (err) {
-    // Ignore if nothing was stored (e.g. first run or already logged out)
+    if (isNoCacheToDeleteError(err)) {
+      return; // Nothing was stored (e.g. first run or already logged out)
+    }
+    throw err;
   }
 }
 

--- a/src/msal-cache.ts
+++ b/src/msal-cache.ts
@@ -65,8 +65,7 @@ async function createCachePersistence() {
       if (allowPlaintext) {
         console.error(
           "Warning: libsecret unavailable, falling back to unencrypted " +
-            "token cache. Set TEAMS_MCP_ALLOW_PLAINTEXT_CACHE=true to " +
-            "suppress this warning in environments without a keyring."
+            "token cache because TEAMS_MCP_ALLOW_PLAINTEXT_CACHE=true."
         );
         return await FilePersistence.create(CACHE_PATH);
       }

--- a/src/msal-cache.ts
+++ b/src/msal-cache.ts
@@ -19,7 +19,8 @@ import {
 const CACHE_PATH = join(homedir(), ".teams-mcp-token-cache.json");
 
 /**
- * Creates the appropriate OS-native persistence backend and wraps it in
+ * Creates the OS-native persistence used for the token cache (shared by
+ * createCachePlugin and clearTokenCache). Returns a backend suitable for
  * PersistenceCachePlugin, which implements the ICachePlugin interface that
  * PublicClientApplication expects.
  *
@@ -33,7 +34,6 @@ const CACHE_PATH = join(homedir(), ".teams-mcp-token-cache.json");
  *             Set TEAMS_MCP_ALLOW_PLAINTEXT_CACHE=true to fall back to an
  *             unencrypted file when libsecret is unavailable.
  */
-/** Creates the OS-native persistence used for the token cache (shared by createCachePlugin and clearTokenCache). */
 async function createCachePersistence() {
   const platform = process.platform;
 

--- a/src/msal-cache.ts
+++ b/src/msal-cache.ts
@@ -33,68 +33,81 @@ const CACHE_PATH = join(homedir(), ".teams-mcp-token-cache.json");
  *             Set TEAMS_MCP_ALLOW_PLAINTEXT_CACHE=true to fall back to an
  *             unencrypted file when libsecret is unavailable.
  */
-export async function createCachePlugin(): Promise<ICachePlugin> {
+/** Creates the OS-native persistence used for the token cache (shared by createCachePlugin and clearTokenCache). */
+async function createCachePersistence(): Promise<
+  Awaited<ReturnType<typeof KeychainPersistence.create>> &
+    { delete: () => Promise<void> }
+> {
   const platform = process.platform;
 
   if (platform === "darwin") {
-    // macOS: Keychain — tokens never written to disk in plaintext
-    const persistence = await KeychainPersistence.create(
+    return await KeychainPersistence.create(
       CACHE_PATH,
-      "teams-mcp",           // Keychain service name
-      "MSALCache"            // Keychain account name
+      "teams-mcp",
+      "MSALCache"
     );
-    return new PersistenceCachePlugin(persistence);
   }
 
   if (platform === "win32") {
-    // Windows: DPAPI-encrypted file — only decryptable by the current user
-    const persistence = await FilePersistenceWithDataProtection.create(
+    return await FilePersistenceWithDataProtection.create(
       CACHE_PATH,
       DataProtectionScope.CurrentUser
     );
-    return new PersistenceCachePlugin(persistence);
   }
 
   if (platform === "linux") {
-    // Linux: libsecret (Secret Service API)
-    // Optional plaintext fallback for headless/CI environments
     const allowPlaintext =
       process.env.TEAMS_MCP_ALLOW_PLAINTEXT_CACHE === "true";
-
     try {
-      const persistence = await LibSecretPersistence.create(
+      return await LibSecretPersistence.create(
         CACHE_PATH,
-        "teams-mcp",         // Secret Service schema name
-        "MSALCache"          // Secret Service collection
+        "teams-mcp",
+        "MSALCache"
       );
-      return new PersistenceCachePlugin(persistence);
     } catch (err) {
       if (allowPlaintext) {
         console.error(
           "Warning: libsecret unavailable, falling back to unencrypted " +
-          "token cache. Set TEAMS_MCP_ALLOW_PLAINTEXT_CACHE=true to " +
-          "suppress this warning in environments without a keyring."
+            "token cache. Set TEAMS_MCP_ALLOW_PLAINTEXT_CACHE=true to " +
+            "suppress this warning in environments without a keyring."
         );
-        const persistence = await FilePersistence.create(CACHE_PATH);
-        return new PersistenceCachePlugin(persistence);
+        return await FilePersistence.create(CACHE_PATH);
       }
       throw new Error(
         "Unable to initialise secure token cache on Linux: libsecret is " +
-        "not available. Install libsecret-1-dev (Debian/Ubuntu) or " +
-        "libsecret-devel (Fedora/RHEL), or set " +
-        "TEAMS_MCP_ALLOW_PLAINTEXT_CACHE=true to use an unencrypted file " +
-        "instead.\n\nOriginal error: " + String(err)
+          "not available. Install libsecret-1-dev (Debian/Ubuntu) or " +
+          "libsecret-devel (Fedora/RHEL), or set " +
+          "TEAMS_MCP_ALLOW_PLAINTEXT_CACHE=true to use an unencrypted file " +
+          "instead.\n\nOriginal error: " +
+          String(err)
       );
     }
   }
 
-  // Unsupported platform — best-effort unencrypted file with a clear warning
   console.error(
     `Warning: Secure token storage is not supported on platform "${platform}". ` +
-    "Tokens will be stored in an unencrypted file at " + CACHE_PATH
+      "Tokens will be stored in an unencrypted file at " +
+      CACHE_PATH
   );
-  const persistence = await FilePersistence.create(CACHE_PATH);
+  return await FilePersistence.create(CACHE_PATH);
+}
+
+export async function createCachePlugin(): Promise<ICachePlugin> {
+  const persistence = await createCachePersistence();
   return new PersistenceCachePlugin(persistence);
+}
+
+/**
+ * Clears the token cache from OS-native storage (Keychain, DPAPI, or libsecret).
+ * Call this on logout so credentials are fully removed.
+ */
+export async function clearTokenCache(): Promise<void> {
+  try {
+    const persistence = await createCachePersistence();
+    await persistence.delete();
+  } catch (err) {
+    // Ignore if nothing was stored (e.g. first run or already logged out)
+  }
 }
 
 export { CACHE_PATH };

--- a/src/msal-cache.ts
+++ b/src/msal-cache.ts
@@ -1,37 +1,100 @@
-import { promises as fs } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { ICachePlugin, TokenCacheContext } from "@azure/msal-node";
+import type { ICachePlugin } from "@azure/msal-node";
+import {
+  DataProtectionScope,
+  FilePersistence,
+  FilePersistenceWithDataProtection,
+  KeychainPersistence,
+  LibSecretPersistence,
+  PersistenceCachePlugin,
+} from "@azure/msal-node-extensions";
 
+// Secure cache location — same directory convention as before but now encrypted
+// - macOS:   stored in Keychain (file path used only as a lock/metadata file)
+// - Windows: DPAPI-encrypted file at this path
+// - Linux:   libsecret keyring (file path used only as a lock/metadata file)
+//            falls back to plaintext file if libsecret is unavailable and
+//            TEAMS_MCP_ALLOW_PLAINTEXT_CACHE=true is set
 const CACHE_PATH = join(homedir(), ".teams-mcp-token-cache.json");
 
 /**
- * Custom file-based cache plugin for MSAL Node
- * Stores tokens (including refresh tokens) in a JSON file
+ * Creates the appropriate OS-native persistence backend and wraps it in
+ * PersistenceCachePlugin, which implements the ICachePlugin interface that
+ * PublicClientApplication expects.
+ *
+ * Platform behaviour:
+ *   macOS   — Tokens stored in the login Keychain under the service name
+ *             "teams-mcp". The cache file on disk is only used as a lock file.
+ *   Windows — Tokens written to CACHE_PATH encrypted with Windows DPAPI
+ *             (CurrentUser scope). Only decryptable by the same user account.
+ *   Linux   — Tokens stored in the system Secret Service (libsecret / GNOME
+ *             Keyring / KWallet). Requires libsecret-1-dev to be installed.
+ *             Set TEAMS_MCP_ALLOW_PLAINTEXT_CACHE=true to fall back to an
+ *             unencrypted file when libsecret is unavailable.
  */
-export const cachePlugin: ICachePlugin = {
-  async beforeCacheAccess(cacheContext: TokenCacheContext): Promise<void> {
-    try {
-      const data = await fs.readFile(CACHE_PATH, "utf8");
-      cacheContext.tokenCache.deserialize(data);
-    } catch (error) {
-      // File doesn't exist or is invalid - start with empty cache
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-        console.error("Warning: Could not read token cache:", error);
-      }
-    }
-  },
+export async function createCachePlugin(): Promise<ICachePlugin> {
+  const platform = process.platform;
 
-  async afterCacheAccess(cacheContext: TokenCacheContext): Promise<void> {
-    if (cacheContext.cacheHasChanged) {
-      try {
-        const data = cacheContext.tokenCache.serialize();
-        await fs.writeFile(CACHE_PATH, data, "utf8");
-      } catch (error) {
-        console.error("Warning: Could not write token cache:", error);
+  if (platform === "darwin") {
+    // macOS: Keychain — tokens never written to disk in plaintext
+    const persistence = await KeychainPersistence.create(
+      CACHE_PATH,
+      "teams-mcp",           // Keychain service name
+      "MSALCache"            // Keychain account name
+    );
+    return new PersistenceCachePlugin(persistence);
+  }
+
+  if (platform === "win32") {
+    // Windows: DPAPI-encrypted file — only decryptable by the current user
+    const persistence = await FilePersistenceWithDataProtection.create(
+      CACHE_PATH,
+      DataProtectionScope.CurrentUser
+    );
+    return new PersistenceCachePlugin(persistence);
+  }
+
+  if (platform === "linux") {
+    // Linux: libsecret (Secret Service API)
+    // Optional plaintext fallback for headless/CI environments
+    const allowPlaintext =
+      process.env.TEAMS_MCP_ALLOW_PLAINTEXT_CACHE === "true";
+
+    try {
+      const persistence = await LibSecretPersistence.create(
+        CACHE_PATH,
+        "teams-mcp",         // Secret Service schema name
+        "MSALCache"          // Secret Service collection
+      );
+      return new PersistenceCachePlugin(persistence);
+    } catch (err) {
+      if (allowPlaintext) {
+        console.error(
+          "Warning: libsecret unavailable, falling back to unencrypted " +
+          "token cache. Set TEAMS_MCP_ALLOW_PLAINTEXT_CACHE=true to " +
+          "suppress this warning in environments without a keyring."
+        );
+        const persistence = await FilePersistence.create(CACHE_PATH);
+        return new PersistenceCachePlugin(persistence);
       }
+      throw new Error(
+        "Unable to initialise secure token cache on Linux: libsecret is " +
+        "not available. Install libsecret-1-dev (Debian/Ubuntu) or " +
+        "libsecret-devel (Fedora/RHEL), or set " +
+        "TEAMS_MCP_ALLOW_PLAINTEXT_CACHE=true to use an unencrypted file " +
+        "instead.\n\nOriginal error: " + String(err)
+      );
     }
-  },
-};
+  }
+
+  // Unsupported platform — best-effort unencrypted file with a clear warning
+  console.error(
+    `Warning: Secure token storage is not supported on platform "${platform}". ` +
+    "Tokens will be stored in an unencrypted file at " + CACHE_PATH
+  );
+  const persistence = await FilePersistence.create(CACHE_PATH);
+  return new PersistenceCachePlugin(persistence);
+}
 
 export { CACHE_PATH };

--- a/src/secure-storage.ts
+++ b/src/secure-storage.ts
@@ -1,0 +1,103 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  DataProtectionScope,
+  FilePersistence,
+  FilePersistenceWithDataProtection,
+  KeychainPersistence,
+  LibSecretPersistence,
+} from "@azure/msal-node-extensions";
+
+// Auth info is stored in OS secure storage (Keychain / DPAPI / libsecret)
+// so we don't keep a plaintext file with account/scopes metadata.
+const AUTH_INFO_PATH = join(homedir(), ".teams-mcp-auth.json");
+
+type PersistenceLike = {
+  load: () => Promise<string | Buffer>;
+  save: (contents: string) => Promise<void>;
+  delete: () => Promise<void>;
+};
+
+async function createAuthInfoPersistence(): Promise<PersistenceLike> {
+  const platform = process.platform;
+  const serviceName = "teams-mcp";
+  const accountName = "AuthInfo";
+
+  if (platform === "darwin") {
+    return await KeychainPersistence.create(
+      AUTH_INFO_PATH,
+      serviceName,
+      accountName
+    );
+  }
+
+  if (platform === "win32") {
+    return await FilePersistenceWithDataProtection.create(
+      AUTH_INFO_PATH,
+      DataProtectionScope.CurrentUser
+    );
+  }
+
+  if (platform === "linux") {
+    const allowPlaintext =
+      process.env.TEAMS_MCP_ALLOW_PLAINTEXT_CACHE === "true";
+    try {
+      return await LibSecretPersistence.create(
+        AUTH_INFO_PATH,
+        serviceName,
+        accountName
+      );
+    } catch {
+      if (allowPlaintext) {
+        return await FilePersistence.create(AUTH_INFO_PATH);
+      }
+      throw new Error(
+        "Unable to use secure storage for auth info on Linux. Install libsecret-1-dev or set TEAMS_MCP_ALLOW_PLAINTEXT_CACHE=true."
+      );
+    }
+  }
+
+  // Unsupported platform: fall back to plaintext file
+  return await FilePersistence.create(AUTH_INFO_PATH);
+}
+
+function bufferToString(data: string | Buffer): string {
+  return typeof data === "string" ? data : data.toString("utf8");
+}
+
+/**
+ * Reads auth info from OS-native secure storage (Keychain, DPAPI, or libsecret).
+ * Returns undefined if nothing is stored or read fails.
+ */
+export async function readAuthInfoSecure(): Promise<string | undefined> {
+  try {
+    const persistence = await createAuthInfoPersistence();
+    const data = await persistence.load();
+    if (data === undefined || data === null) return undefined;
+    return bufferToString(data);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Writes auth info to OS-native secure storage.
+ */
+export async function writeAuthInfoSecure(contents: string): Promise<void> {
+  const persistence = await createAuthInfoPersistence();
+  await persistence.save(contents);
+}
+
+/**
+ * Deletes auth info from OS-native secure storage (e.g. on logout).
+ */
+export async function deleteAuthInfoSecure(): Promise<void> {
+  try {
+    const persistence = await createAuthInfoPersistence();
+    await persistence.delete();
+  } catch {
+    // Ignore if nothing was stored
+  }
+}
+
+export { AUTH_INFO_PATH };

--- a/src/secure-storage.ts
+++ b/src/secure-storage.ts
@@ -31,8 +31,11 @@ async function createPlaintextPersistence(): Promise<PersistenceLike> {
       try {
         await fs.unlink(AUTH_INFO_PATH);
         return true;
-      } catch {
-        return false;
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+          return false;
+        }
+        throw err;
       }
     },
   };

--- a/src/secure-storage.ts
+++ b/src/secure-storage.ts
@@ -1,67 +1,120 @@
+import { promises as fs } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
-import {
-  DataProtectionScope,
-  FilePersistence,
-  FilePersistenceWithDataProtection,
-  KeychainPersistence,
-  LibSecretPersistence,
-} from "@azure/msal-node-extensions";
+import { dirname, join } from "node:path";
 
 // Auth info is stored in OS secure storage (Keychain / DPAPI / libsecret)
 // so we don't keep a plaintext file with account/scopes metadata.
 const AUTH_INFO_PATH = join(homedir(), ".teams-mcp-auth.json");
 
 type PersistenceLike = {
-  load: () => Promise<string | Buffer>;
+  load: () => Promise<string | Buffer | null>;
   save: (contents: string) => Promise<void>;
-  delete: () => Promise<void>;
+  delete: () => Promise<boolean | void>;
 };
 
+/** Plaintext file persistence used when native secure storage is unavailable or disabled. */
+async function createPlaintextPersistence(): Promise<PersistenceLike> {
+  return {
+    async load() {
+      try {
+        const data = await fs.readFile(AUTH_INFO_PATH, "utf8");
+        return data;
+      } catch {
+        return null;
+      }
+    },
+    async save(contents: string) {
+      await fs.mkdir(dirname(AUTH_INFO_PATH), { recursive: true });
+      await fs.writeFile(AUTH_INFO_PATH, contents, "utf8");
+    },
+    async delete() {
+      try {
+        await fs.unlink(AUTH_INFO_PATH);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  };
+}
+
 async function createAuthInfoPersistence(): Promise<PersistenceLike> {
+  const allowPlaintext =
+    process.env.TEAMS_MCP_ALLOW_PLAINTEXT_CACHE === "true";
   const platform = process.platform;
   const serviceName = "teams-mcp";
   const accountName = "AuthInfo";
 
-  if (platform === "darwin") {
-    return await KeychainPersistence.create(
-      AUTH_INFO_PATH,
-      serviceName,
-      accountName
-    );
+  // When plaintext is explicitly allowed, skip loading native module (avoids libsecret etc. on Linux).
+  if (allowPlaintext) {
+    return createPlaintextPersistence();
   }
 
-  if (platform === "win32") {
-    return await FilePersistenceWithDataProtection.create(
-      AUTH_INFO_PATH,
-      DataProtectionScope.CurrentUser
-    );
-  }
+  try {
+    const {
+      DataProtectionScope,
+      FilePersistence,
+      FilePersistenceWithDataProtection,
+      KeychainPersistence,
+      LibSecretPersistence,
+    } = await import("@azure/msal-node-extensions");
 
-  if (platform === "linux") {
-    const allowPlaintext =
-      process.env.TEAMS_MCP_ALLOW_PLAINTEXT_CACHE === "true";
-    try {
-      return await LibSecretPersistence.create(
+    if (platform === "darwin") {
+      return (await KeychainPersistence.create(
         AUTH_INFO_PATH,
         serviceName,
         accountName
-      );
-    } catch {
-      if (allowPlaintext) {
-        return await FilePersistence.create(AUTH_INFO_PATH);
-      }
-      throw new Error(
-        "Unable to use secure storage for auth info on Linux. Install libsecret-1-dev or set TEAMS_MCP_ALLOW_PLAINTEXT_CACHE=true."
-      );
+      )) as PersistenceLike;
     }
-  }
 
-  // Unsupported platform: fall back to plaintext file
-  return await FilePersistence.create(AUTH_INFO_PATH);
+    if (platform === "win32") {
+      return (await FilePersistenceWithDataProtection.create(
+        AUTH_INFO_PATH,
+        DataProtectionScope.CurrentUser
+      )) as PersistenceLike;
+    }
+
+    if (platform === "linux") {
+      try {
+        return (await LibSecretPersistence.create(
+          AUTH_INFO_PATH,
+          serviceName,
+          accountName
+        )) as PersistenceLike;
+      } catch (err) {
+        console.error(
+          "Secure storage (libsecret) unavailable, falling back to plaintext file:",
+          err
+        );
+        return createPlaintextPersistence();
+      }
+    }
+
+    // Unsupported platform: fall back to plaintext file
+    return (await FilePersistence.create(AUTH_INFO_PATH)) as PersistenceLike;
+  } catch (err) {
+    console.error(
+      "Could not load or use native secure storage, falling back to plaintext file:",
+      err
+    );
+    return createPlaintextPersistence();
+  }
 }
 
-function bufferToString(data: string | Buffer): string {
+/** True if the error indicates a missing entry and can be ignored on delete. */
+function isNotFoundError(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException).code;
+  const name = err instanceof Error ? err.name : "";
+  const message = err instanceof Error ? err.message : String(err);
+  if (code === "ENOENT" || code === "ENOTFOUND") return true;
+  if (name === "NotFoundError" || /NotFound/i.test(name)) return true;
+  return /not found|no such file|does not exist|no entry|could not find/i.test(
+    message
+  );
+}
+
+function bufferToString(data: string | Buffer | null): string {
+  if (data === null) return "";
   return typeof data === "string" ? data : data.toString("utf8");
 }
 
@@ -95,8 +148,11 @@ export async function deleteAuthInfoSecure(): Promise<void> {
   try {
     const persistence = await createAuthInfoPersistence();
     await persistence.delete();
-  } catch {
-    // Ignore if nothing was stored
+  } catch (err) {
+    if (isNotFoundError(err)) {
+      return; // Nothing was stored
+    }
+    throw err;
   }
 }
 

--- a/src/secure-storage.ts
+++ b/src/secure-storage.ts
@@ -85,22 +85,39 @@ async function createAuthInfoPersistence(): Promise<PersistenceLike> {
           accountName
         )) as PersistenceLike;
       } catch (err) {
-        console.error(
-          "Secure storage (libsecret) unavailable, falling back to plaintext file:",
-          err
+        throw new Error(
+          "Unable to initialise secure auth storage on Linux: libsecret is " +
+            "not available. Install libsecret-1-dev (Debian/Ubuntu) or " +
+            "libsecret-devel (Fedora/RHEL), or set " +
+            "TEAMS_MCP_ALLOW_PLAINTEXT_CACHE=true to use an unencrypted file " +
+            "instead.\n\nOriginal error: " +
+            String(err)
         );
-        return createPlaintextPersistence();
       }
     }
 
-    // Unsupported platform: fall back to plaintext file
-    return (await FilePersistence.create(AUTH_INFO_PATH)) as PersistenceLike;
-  } catch (err) {
-    console.error(
-      "Could not load or use native secure storage, falling back to plaintext file:",
-      err
-    );
+    // Unsupported platform: require explicit opt-in for plaintext
+    if (!allowPlaintext) {
+      throw new Error(
+        `Secure auth storage is not supported on platform "${platform}". ` +
+          `Set TEAMS_MCP_ALLOW_PLAINTEXT_CACHE=true to use an unencrypted file at ${AUTH_INFO_PATH} instead.`
+      );
+    }
     return createPlaintextPersistence();
+  } catch (err) {
+    if (allowPlaintext) {
+      console.error(
+        "Could not load or use native secure storage, falling back to plaintext file:",
+        err
+      );
+      return createPlaintextPersistence();
+    }
+    throw new Error(
+      "Could not load native secure storage module. Set " +
+        "TEAMS_MCP_ALLOW_PLAINTEXT_CACHE=true to use an unencrypted file instead.\n\n" +
+        "Original error: " +
+        String(err)
+    );
   }
 }
 

--- a/src/services/graph.ts
+++ b/src/services/graph.ts
@@ -1,6 +1,6 @@
 import { type AccountInfo, PublicClientApplication } from "@azure/msal-node";
 import { Client } from "@microsoft/microsoft-graph-client";
-import { cachePlugin } from "../msal-cache.js";
+import { createCachePlugin } from "../msal-cache.js";
 
 const CLIENT_ID = "14d82eec-204b-4c2f-b7e8-296a70dab67e";
 const AUTHORITY = "https://login.microsoftonline.com/common";
@@ -82,6 +82,7 @@ export class GraphService {
       }
 
       // Priority 2: MSAL with cached refresh token for automatic token renewal
+      const cachePlugin = await createCachePlugin();
       this.msalApp = new PublicClientApplication({
         auth: {
           clientId: CLIENT_ID,


### PR DESCRIPTION
**Summary**
Uses OS-native secure storage for tokens and auth metadata so credentials are no longer kept in plaintext files.

**Changes**

- MSAL token cache
- - Refactored around a shared createCachePersistence() helper.
- - Added clearTokenCache() so logout removes tokens from Keychain / DPAPI / libsecret instead of only deleting the on-disk file.

- Auth metadata
- - New src/secure-storage.ts stores auth info (account, scopes, timestamps) in the same backends:
- - - macOS: Keychain
- - - Windows: DPAPI
- - - Linux: libsecret (or plaintext file if TEAMS_MCP_ALLOW_PLAINTEXT_CACHE=true)

- src/index.ts
- - Reads/writes auth via readAuthInfoSecure() / writeAuthInfoSecure().
- - Migration: If the legacy plaintext .msgraph-mcp-auth.json exists, it is read once, written into secure storage, then deleted.
- - Logout calls deleteAuthInfoSecure() and clearTokenCache() so both auth metadata and token cache are cleared.

- Tests
- - src/__tests__/msal-cache.test.ts updated for async createCachePlugin() and the refactor; added a test for clearTokenCache().

**Platform behaviour (unchanged)**
- macOS: Keychain (service teams-mcp).
- Windows: DPAPI (CurrentUser) at the existing cache path.
- Linux: libsecret, with optional plaintext fallback when TEAMS_MCP_ALLOW_PLAINTEXT_CACHE=true.

**Backward compatibility**
Existing users with only the legacy .msgraph-mcp-auth.json file are migrated automatically on next read; no manual steps required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Credentials and MSAL token cache now use OS-native secure storage with automatic migration from the legacy plaintext file.
  * Added ability to clear the OS-native token cache (used during logout/cleanup).

* **Chores**
  * Added a new dependency to support OS-native secure persistence.

* **Tests**
  * Expanded tests covering secure storage, migration, cache read/write/delete behaviors, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->