### PR TITLE
fix: use owner role for oneOnOne chat members

### DIFF
--- a/src/tools/__tests__/chats.test.ts
+++ b/src/tools/__tests__/chats.test.ts
@@ -1041,7 +1041,7 @@ describe("Chat Tools", () => {
           {
             "@odata.type": "#microsoft.graph.aadUserConversationMember",
             user: { id: "otheruser456" },
-            roles: ["member"],
+            roles: ["owner"],
           },
         ],
       });

--- a/src/tools/chats.ts
+++ b/src/tools/chats.ts
@@ -640,7 +640,9 @@ export function registerChatTools(
           } as ConversationMember,
         ];
 
-        // Add other users as members
+        // Add other users
+        // For oneOnOne chats, all members must have "owner" role
+        const isOneOnOne = userEmails.length === 1;
         for (const email of userEmails) {
           const user = (await client.api(`/users/${email}`).get()) as User;
           members.push({
@@ -648,7 +650,7 @@ export function registerChatTools(
             user: {
               id: user?.id,
             },
-            roles: ["member"],
+            roles: [isOneOnOne ? "owner" : "member"],
           } as ConversationMember);
         }
 

--- a/src/tools/chats.ts
+++ b/src/tools/chats.ts
@@ -655,11 +655,11 @@ export function registerChatTools(
         }
 
         const chatData: CreateChatPayload = {
-          chatType: userEmails.length === 1 ? "oneOnOne" : "group",
+          chatType: isOneOnOne ? "oneOnOne" : "group",
           members,
         };
 
-        if (topic && userEmails.length > 1) {
+        if (topic && !isOneOnOne) {
           chatData.topic = topic;
         }
 


### PR DESCRIPTION
## Summary
- Fix `create_chat` failing for 1:1 (oneOnOne) chats with error: `The passed-in role 'member' is not supported`
- The Microsoft Graph API requires **all members** in a oneOnOne chat to have the `owner` role
- Group chats continue to use `member` role for non-creator participants

## Problem
When creating a oneOnOne chat, the second user was added with `roles: ["member"]`, but the Graph API rejects this with:
```
The passed-in role 'member' is not supported.
```

## Fix
Set the role to `"owner"` when `chatType` is `"oneOnOne"` (i.e., `userEmails.length === 1`), and keep `"member"` for group chats.

## Test plan
- [x] Create a 1:1 chat with `create_chat` — now succeeds
- [x] Send a message to the created chat — works
- [ ] Create a group chat — should still work (role remains "member")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed role assignment in one-on-one chats so the other participant is granted ownership; group chat role behavior remains member-based.
  * Topic now applies only to group chats and will not be set for one-on-one conversations.

* **Tests**
  * Updated tests to reflect the corrected one-on-one role assignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->