### PR TITLE
fix: create sharing link for chat file attachments

### DIFF
--- a/src/utils/__tests__/file-upload.test.ts
+++ b/src/utils/__tests__/file-upload.test.ts
@@ -304,9 +304,17 @@ describe("uploadFileToChat", () => {
           return {
             header: vi.fn().mockReturnValue({
               put: vi.fn().mockResolvedValue({
+                id: "uploaded-item-id",
                 webUrl: "https://onedrive.com/chat-file.docx",
                 eTag: '"{DDDD-EEEE-FFFF},1"',
               }),
+            }),
+          };
+        }
+        if (path.includes("/createLink")) {
+          return {
+            post: vi.fn().mockResolvedValue({
+              link: { webUrl: "https://share.onedrive.com/org-link" },
             }),
           };
         }
@@ -322,7 +330,7 @@ describe("uploadFileToChat", () => {
   it("should upload a file to chat and return correct result", async () => {
     const result = await uploadFileToChat(mockGraphService, "/tmp/document.docx");
 
-    expect(result.webUrl).toBe("https://onedrive.com/chat-file.docx");
+    expect(result.webUrl).toBe("https://share.onedrive.com/org-link");
     expect(result.attachmentId).toBe("DDDD-EEEE-FFFF");
     expect(result.fileName).toBe("document.docx");
     expect(result.mimeType).toBe(
@@ -365,5 +373,116 @@ describe("uploadFileToChat", () => {
     await expect(uploadFileToChat(mockGraphService, "/tmp/file.pdf")).rejects.toThrow(
       "Failed to resolve user drive ID"
     );
+  });
+
+  it("should create organization sharing link and use its URL", async () => {
+    const result = await uploadFileToChat(mockGraphService, "/tmp/file.txt");
+
+    expect(result.webUrl).toBe("https://share.onedrive.com/org-link");
+
+    const apiCalls = mockClient.api.mock.calls.map((c: any[]) => c[0]);
+    const createLinkCall = apiCalls.find((p: string) => p.includes("/createLink"));
+    expect(createLinkCall).toBe("/drives/user-drive-id/items/uploaded-item-id/createLink");
+  });
+
+  it("should fall back to 'users' scope when organization scope fails", async () => {
+    let createLinkCallCount = 0;
+    mockClient.api.mockImplementation((path: string) => {
+      if (path === "/me/drive") {
+        return {
+          get: vi.fn().mockResolvedValue({ id: "user-drive-id" }),
+        };
+      }
+      if (path.includes("/content")) {
+        return {
+          header: vi.fn().mockReturnValue({
+            put: vi.fn().mockResolvedValue({
+              id: "uploaded-item-id",
+              webUrl: "https://onedrive.com/direct-url",
+              eTag: '"{DDDD-EEEE-FFFF},1"',
+            }),
+          }),
+        };
+      }
+      if (path.includes("/createLink")) {
+        createLinkCallCount++;
+        if (createLinkCallCount === 1) {
+          return {
+            post: vi.fn().mockRejectedValue(new Error("Organization scope disabled by policy")),
+          };
+        }
+        return {
+          post: vi.fn().mockResolvedValue({
+            link: { webUrl: "https://share.onedrive.com/users-link" },
+          }),
+        };
+      }
+      return { get: vi.fn(), post: vi.fn() };
+    });
+
+    const result = await uploadFileToChat(mockGraphService, "/tmp/file.txt");
+
+    expect(result.webUrl).toBe("https://share.onedrive.com/users-link");
+    expect(createLinkCallCount).toBe(2);
+  });
+
+  it("should fall back to direct webUrl when both sharing scopes fail", async () => {
+    mockClient.api.mockImplementation((path: string) => {
+      if (path === "/me/drive") {
+        return {
+          get: vi.fn().mockResolvedValue({ id: "user-drive-id" }),
+        };
+      }
+      if (path.includes("/content")) {
+        return {
+          header: vi.fn().mockReturnValue({
+            put: vi.fn().mockResolvedValue({
+              id: "uploaded-item-id",
+              webUrl: "https://onedrive.com/direct-url",
+              eTag: '"{DDDD-EEEE-FFFF},1"',
+            }),
+          }),
+        };
+      }
+      if (path.includes("/createLink")) {
+        return {
+          post: vi.fn().mockRejectedValue(new Error("Sharing links disabled")),
+        };
+      }
+      return { get: vi.fn(), post: vi.fn() };
+    });
+
+    const result = await uploadFileToChat(mockGraphService, "/tmp/file.txt");
+
+    expect(result.webUrl).toBe("https://onedrive.com/direct-url");
+  });
+
+  it("should fall back to direct webUrl when upload result has no id", async () => {
+    mockClient.api.mockImplementation((path: string) => {
+      if (path === "/me/drive") {
+        return {
+          get: vi.fn().mockResolvedValue({ id: "user-drive-id" }),
+        };
+      }
+      if (path.includes("/content")) {
+        return {
+          header: vi.fn().mockReturnValue({
+            put: vi.fn().mockResolvedValue({
+              webUrl: "https://onedrive.com/no-id-file.txt",
+              eTag: '"{AAAA-BBBB-CCCC},1"',
+            }),
+          }),
+        };
+      }
+      return { get: vi.fn(), post: vi.fn() };
+    });
+
+    const result = await uploadFileToChat(mockGraphService, "/tmp/file.txt");
+
+    expect(result.webUrl).toBe("https://onedrive.com/no-id-file.txt");
+    // Verify createLink was never called (no id means no sharing link attempt)
+    const apiCalls = mockClient.api.mock.calls.map((c: any[]) => c[0]);
+    const createLinkCalls = apiCalls.filter((p: string) => p.includes("/createLink"));
+    expect(createLinkCalls).toHaveLength(0);
   });
 });

--- a/src/utils/file-upload.ts
+++ b/src/utils/file-upload.ts
@@ -56,6 +56,7 @@ export interface FileUploadResult {
 
 /** Graph API response from a DriveItem upload (simple PUT or final chunk). */
 type DriveItemUploadResponse = {
+  id?: string;
   webUrl?: string;
   eTag?: string;
 };
@@ -111,7 +112,7 @@ async function simpleUpload(
   remotePath: string,
   fileBuffer: Buffer,
   mimeType: string
-): Promise<{ webUrl: string; eTag: string }> {
+): Promise<{ webUrl: string; eTag: string; id: string }> {
   const client = await graphService.getClient();
   const response = (await client
     .api(`/drives/${driveId}/items/${parentItemId}:/${remotePath}:/content`)
@@ -120,7 +121,7 @@ async function simpleUpload(
   if (!response?.webUrl || !response?.eTag) {
     throw new Error("Upload failed: response did not contain webUrl/eTag");
   }
-  return { webUrl: response.webUrl, eTag: response.eTag };
+  return { webUrl: response.webUrl, eTag: response.eTag, id: response.id ?? "" };
 }
 
 /**
@@ -133,7 +134,7 @@ async function uploadLargeFile(
   parentItemId: string,
   remotePath: string,
   fileBuffer: Buffer
-): Promise<{ webUrl: string; eTag: string }> {
+): Promise<{ webUrl: string; eTag: string; id: string }> {
   const client = await graphService.getClient();
 
   const session = (await client
@@ -187,7 +188,7 @@ async function uploadLargeFile(
   if (!finalResult?.webUrl || !finalResult?.eTag) {
     throw new Error("Upload failed: final response did not contain file metadata");
   }
-  return { webUrl: finalResult.webUrl, eTag: finalResult.eTag };
+  return { webUrl: finalResult.webUrl, eTag: finalResult.eTag, id: finalResult.id ?? "" };
 }
 
 /**
@@ -257,9 +258,38 @@ export async function uploadFileToChat(
       ? await simpleUpload(graphService, driveId, "root", remotePath, buffer, mimeType)
       : await uploadLargeFile(graphService, driveId, "root", remotePath, buffer);
 
+  const attachmentId = extractGuidFromETag(uploadResult.eTag);
+
+  // Create a sharing link and use its URL as contentUrl for the attachment.
+  // Per the Graph API docs, chat message file attachments require a sharing link URL —
+  // using the direct webUrl from the upload causes "permission denied" for recipients.
+  let contentUrl = uploadResult.webUrl;
+  if (uploadResult.id) {
+    try {
+      const linkResponse = await client
+        .api(`/drives/${driveId}/items/${uploadResult.id}/createLink`)
+        .post({ type: "view", scope: "organization" });
+      if (linkResponse?.link?.webUrl) {
+        contentUrl = linkResponse.link.webUrl;
+      }
+    } catch {
+      // Fallback: try "users" scope if "organization" is blocked by tenant policy
+      try {
+        const linkResponse = await client
+          .api(`/drives/${driveId}/items/${uploadResult.id}/createLink`)
+          .post({ type: "view", scope: "users" });
+        if (linkResponse?.link?.webUrl) {
+          contentUrl = linkResponse.link.webUrl;
+        }
+      } catch {
+        // Last resort: use the direct webUrl (may not work for recipients)
+      }
+    }
+  }
+
   return {
-    webUrl: uploadResult.webUrl,
-    attachmentId: extractGuidFromETag(uploadResult.eTag),
+    webUrl: contentUrl,
+    attachmentId,
     fileName,
     fileSize: size,
     mimeType,

--- a/src/utils/file-upload.ts
+++ b/src/utils/file-upload.ts
@@ -72,6 +72,13 @@ type ChannelFilesFolderResponse = {
   parentReference?: { driveId?: string };
 };
 
+/** Graph API response from the createLink endpoint. */
+type CreateLinkResponse = {
+  link?: {
+    webUrl?: string;
+  };
+};
+
 /**
  * Detect MIME type from file extension.
  */
@@ -266,23 +273,31 @@ export async function uploadFileToChat(
   let contentUrl = uploadResult.webUrl;
   if (uploadResult.id) {
     try {
-      const linkResponse = await client
+      const linkResponse = (await client
         .api(`/drives/${driveId}/items/${uploadResult.id}/createLink`)
-        .post({ type: "view", scope: "organization" });
+        .post({ type: "view", scope: "organization" })) as CreateLinkResponse;
       if (linkResponse?.link?.webUrl) {
         contentUrl = linkResponse.link.webUrl;
       }
-    } catch {
+    } catch (orgErr: unknown) {
       // Fallback: try "users" scope if "organization" is blocked by tenant policy
+      console.error(
+        `[teams-mcp] createLink (organization) failed for item ${uploadResult.id}:`,
+        orgErr instanceof Error ? orgErr.message : orgErr
+      );
       try {
-        const linkResponse = await client
+        const linkResponse = (await client
           .api(`/drives/${driveId}/items/${uploadResult.id}/createLink`)
-          .post({ type: "view", scope: "users" });
+          .post({ type: "view", scope: "users" })) as CreateLinkResponse;
         if (linkResponse?.link?.webUrl) {
           contentUrl = linkResponse.link.webUrl;
         }
-      } catch {
+      } catch (usersErr: unknown) {
         // Last resort: use the direct webUrl (may not work for recipients)
+        console.error(
+          `[teams-mcp] createLink (users) also failed for item ${uploadResult.id}:`,
+          usersErr instanceof Error ? usersErr.message : usersErr
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary

- When sending a file to a chat via `send_file_to_chat`, the uploaded OneDrive file's direct `webUrl` was used as the attachment `contentUrl`. Per the [Graph API docs](https://learn.microsoft.com/en-us/graph/api/chatmessage-post?view=graph-rest-1.0&tabs=http#example-5-send-a-message-with-a-file-attachment-in-it), chat message file attachments require a **sharing link URL** — using the direct `webUrl` causes recipients to get "permission denied" when trying to download.
- This change creates an organization-scoped sharing link via `/drives/{driveId}/items/{itemId}/createLink` after uploading the file and uses that URL as the `contentUrl` in the message attachment.
- Falls back to `"users"` scope if `"organization"` sharing is blocked by tenant policy, and ultimately falls back to the direct `webUrl` if both fail.

## Changes

- Added `id` field to `DriveItemUploadResponse` type and propagated it through `simpleUpload` / `uploadLargeFile` return values
- Added sharing link creation step in `uploadFileToChat()` with two-level fallback
- Returns the sharing link URL as `webUrl` in `FileUploadResult` instead of the direct OneDrive URL

## Test plan

- [x] All 348 existing tests pass
- [x] Manually tested: sent a file to a 1:1 chat — recipient was previously unable to download, now can access the file via the sharing link

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced chat file upload so attachment links prefer organization-scoped sharing links, with user-scoped and direct-link fallbacks when needed.
  * Attachment identifiers and returned content URLs now reflect created sharing links when available.

* **Tests**
  * Added tests covering sharing-link creation and both fallback scenarios, plus handling when no uploaded item id is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->