### PR TITLE
feat: add reactions support for messages

### DIFF
--- a/src/tools/__tests__/chats.test.ts
+++ b/src/tools/__tests__/chats.test.ts
@@ -1190,13 +1190,11 @@ describe("Chat Tools", () => {
               reactionType: "like",
               displayName: "Like",
               createdDateTime: "2023-01-01T10:01:00Z",
-              user: { user: { displayName: "Alice" } },
             },
             {
               reactionType: "heart",
               displayName: "Heart",
               createdDateTime: "2023-01-01T10:02:00Z",
-              user: { user: { displayName: "Bob" } },
             },
           ],
         },
@@ -1214,13 +1212,11 @@ describe("Chat Tools", () => {
       expect(parsedResponse.messages[0].reactions[0]).toEqual({
         reactionType: "like",
         displayName: "Like",
-        user: "Alice",
         createdDateTime: "2023-01-01T10:01:00Z",
       });
       expect(parsedResponse.messages[0].reactions[1]).toEqual({
         reactionType: "heart",
         displayName: "Heart",
-        user: "Bob",
         createdDateTime: "2023-01-01T10:02:00Z",
       });
     });

--- a/src/tools/__tests__/chats.test.ts
+++ b/src/tools/__tests__/chats.test.ts
@@ -39,7 +39,7 @@ describe("Chat Tools", () => {
     it("should register all chat tools", () => {
       registerChatTools(mockServer, mockGraphService, false);
 
-      expect(mockServer.tool).toHaveBeenCalledTimes(8);
+      expect(mockServer.tool).toHaveBeenCalledTimes(10);
       expect(mockServer.tool).toHaveBeenCalledWith(
         "list_chats",
         expect.any(String),
@@ -72,6 +72,18 @@ describe("Chat Tools", () => {
       );
       expect(mockServer.tool).toHaveBeenCalledWith(
         "delete_chat_message",
+        expect.any(String),
+        expect.any(Object),
+        expect.any(Function)
+      );
+      expect(mockServer.tool).toHaveBeenCalledWith(
+        "set_chat_message_reaction",
+        expect.any(String),
+        expect.any(Object),
+        expect.any(Function)
+      );
+      expect(mockServer.tool).toHaveBeenCalledWith(
+        "unset_chat_message_reaction",
         expect.any(String),
         expect.any(Object),
         expect.any(Function)
@@ -1152,6 +1164,188 @@ describe("Chat Tools", () => {
       });
 
       expect(result.content[0].text).toBe("❌ Error: Failed to create chat");
+    });
+  });
+
+  describe("get_chat_messages reactions", () => {
+    let getChatMessagesHandler: (args?: any) => Promise<any>;
+
+    beforeEach(() => {
+      registerChatTools(mockServer, mockGraphService, false);
+      const call = vi
+        .mocked(mockServer.tool)
+        .mock.calls.find(([name]) => name === "get_chat_messages");
+      getChatMessagesHandler = call?.[3] as unknown as (args?: any) => Promise<any>;
+    });
+
+    it("should include reactions in message summaries", async () => {
+      const mockMessages = [
+        {
+          id: "msg1",
+          body: { content: "Hello world" },
+          from: { user: { displayName: "John Doe" } },
+          createdDateTime: "2023-01-01T10:00:00Z",
+          reactions: [
+            {
+              reactionType: "like",
+              displayName: "Like",
+              createdDateTime: "2023-01-01T10:01:00Z",
+            },
+            {
+              reactionType: "heart",
+              displayName: "Heart",
+              createdDateTime: "2023-01-01T10:02:00Z",
+            },
+          ],
+        },
+      ];
+
+      const mockApiChain = {
+        get: vi.fn().mockResolvedValue({ value: mockMessages }),
+      };
+      mockClient.api = vi.fn().mockReturnValue(mockApiChain);
+
+      const result = await getChatMessagesHandler({ chatId: "chat123" });
+      const parsedResponse = JSON.parse(result.content[0].text);
+
+      expect(parsedResponse.messages[0].reactions).toHaveLength(2);
+      expect(parsedResponse.messages[0].reactions[0]).toEqual({
+        reactionType: "like",
+        displayName: "Like",
+        createdDateTime: "2023-01-01T10:01:00Z",
+      });
+      expect(parsedResponse.messages[0].reactions[1]).toEqual({
+        reactionType: "heart",
+        displayName: "Heart",
+        createdDateTime: "2023-01-01T10:02:00Z",
+      });
+    });
+
+    it("should handle messages without reactions", async () => {
+      const mockMessages = [
+        {
+          id: "msg1",
+          body: { content: "No reactions" },
+          from: { user: { displayName: "John" } },
+          createdDateTime: "2023-01-01T10:00:00Z",
+        },
+      ];
+
+      const mockApiChain = {
+        get: vi.fn().mockResolvedValue({ value: mockMessages }),
+      };
+      mockClient.api = vi.fn().mockReturnValue(mockApiChain);
+
+      const result = await getChatMessagesHandler({ chatId: "chat123" });
+      const parsedResponse = JSON.parse(result.content[0].text);
+
+      expect(parsedResponse.messages[0].reactions).toBeUndefined();
+    });
+  });
+
+  describe("set_chat_message_reaction", () => {
+    let setReactionHandler: (args?: any) => Promise<any>;
+
+    beforeEach(() => {
+      registerChatTools(mockServer, mockGraphService, false);
+      const call = vi
+        .mocked(mockServer.tool)
+        .mock.calls.find(([name]) => name === "set_chat_message_reaction");
+      setReactionHandler = call?.[3] as unknown as (args?: any) => Promise<any>;
+    });
+
+    it("should set a reaction on a chat message", async () => {
+      const mockApiChain = {
+        post: vi.fn().mockResolvedValue(undefined),
+      };
+      mockClient.api = vi.fn().mockReturnValue(mockApiChain);
+
+      const result = await setReactionHandler({
+        chatId: "chat123",
+        messageId: "msg456",
+        reactionType: "like",
+      });
+
+      expect(mockClient.api).toHaveBeenCalledWith("/chats/chat123/messages/msg456/setReaction");
+      expect(mockApiChain.post).toHaveBeenCalledWith({ reactionType: "like" });
+      expect(result.content[0].text).toBe("✅ Reaction like added to message msg456.");
+    });
+
+    it("should set a unicode emoji reaction", async () => {
+      const mockApiChain = {
+        post: vi.fn().mockResolvedValue(undefined),
+      };
+      mockClient.api = vi.fn().mockReturnValue(mockApiChain);
+
+      const result = await setReactionHandler({
+        chatId: "chat123",
+        messageId: "msg456",
+        reactionType: "👍",
+      });
+
+      expect(mockApiChain.post).toHaveBeenCalledWith({ reactionType: "👍" });
+      expect(result.content[0].text).toContain("👍");
+    });
+
+    it("should handle errors", async () => {
+      const mockApiChain = {
+        post: vi.fn().mockRejectedValue(new Error("Forbidden")),
+      };
+      mockClient.api = vi.fn().mockReturnValue(mockApiChain);
+
+      const result = await setReactionHandler({
+        chatId: "chat123",
+        messageId: "msg456",
+        reactionType: "like",
+      });
+
+      expect(result.content[0].text).toBe("❌ Failed to set reaction: Forbidden");
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("unset_chat_message_reaction", () => {
+    let unsetReactionHandler: (args?: any) => Promise<any>;
+
+    beforeEach(() => {
+      registerChatTools(mockServer, mockGraphService, false);
+      const call = vi
+        .mocked(mockServer.tool)
+        .mock.calls.find(([name]) => name === "unset_chat_message_reaction");
+      unsetReactionHandler = call?.[3] as unknown as (args?: any) => Promise<any>;
+    });
+
+    it("should unset a reaction on a chat message", async () => {
+      const mockApiChain = {
+        post: vi.fn().mockResolvedValue(undefined),
+      };
+      mockClient.api = vi.fn().mockReturnValue(mockApiChain);
+
+      const result = await unsetReactionHandler({
+        chatId: "chat123",
+        messageId: "msg456",
+        reactionType: "like",
+      });
+
+      expect(mockClient.api).toHaveBeenCalledWith("/chats/chat123/messages/msg456/unsetReaction");
+      expect(mockApiChain.post).toHaveBeenCalledWith({ reactionType: "like" });
+      expect(result.content[0].text).toBe("✅ Reaction like removed from message msg456.");
+    });
+
+    it("should handle errors", async () => {
+      const mockApiChain = {
+        post: vi.fn().mockRejectedValue(new Error("Not found")),
+      };
+      mockClient.api = vi.fn().mockReturnValue(mockApiChain);
+
+      const result = await unsetReactionHandler({
+        chatId: "chat123",
+        messageId: "msg456",
+        reactionType: "like",
+      });
+
+      expect(result.content[0].text).toBe("❌ Failed to unset reaction: Not found");
+      expect(result.isError).toBe(true);
     });
   });
 

--- a/src/tools/__tests__/chats.test.ts
+++ b/src/tools/__tests__/chats.test.ts
@@ -1190,11 +1190,13 @@ describe("Chat Tools", () => {
               reactionType: "like",
               displayName: "Like",
               createdDateTime: "2023-01-01T10:01:00Z",
+              user: { user: { displayName: "Alice" } },
             },
             {
               reactionType: "heart",
               displayName: "Heart",
               createdDateTime: "2023-01-01T10:02:00Z",
+              user: { user: { displayName: "Bob" } },
             },
           ],
         },
@@ -1212,11 +1214,13 @@ describe("Chat Tools", () => {
       expect(parsedResponse.messages[0].reactions[0]).toEqual({
         reactionType: "like",
         displayName: "Like",
+        user: "Alice",
         createdDateTime: "2023-01-01T10:01:00Z",
       });
       expect(parsedResponse.messages[0].reactions[1]).toEqual({
         reactionType: "heart",
         displayName: "Heart",
+        user: "Bob",
         createdDateTime: "2023-01-01T10:02:00Z",
       });
     });

--- a/src/tools/__tests__/teams.test.ts
+++ b/src/tools/__tests__/teams.test.ts
@@ -65,14 +65,16 @@ describe("Teams Tools", () => {
       expect(registeredTools).not.toContain("reply_to_channel_message");
       expect(registeredTools).not.toContain("delete_channel_message");
       expect(registeredTools).not.toContain("update_channel_message");
+      expect(registeredTools).not.toContain("set_channel_message_reaction");
+      expect(registeredTools).not.toContain("unset_channel_message_reaction");
       expect(registeredTools).not.toContain("send_file_to_channel");
     });
 
-    it("should register all 12 tools when readOnly is false", () => {
+    it("should register all 14 tools when readOnly is false", () => {
       registerTeamsTools(mockServer, mockGraphService, false);
 
       const registeredTools = mockServer.getAllTools();
-      expect(registeredTools).toHaveLength(12);
+      expect(registeredTools).toHaveLength(14);
     });
   });
 
@@ -1393,6 +1395,144 @@ describe("Teams Tools", () => {
       });
 
       expect(result.content[0].text).toContain("❌ No hosted content found");
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("set_channel_message_reaction tool", () => {
+    it("should set a reaction on a channel message", async () => {
+      const mockApiChain = {
+        post: vi.fn().mockResolvedValue(undefined),
+        get: vi.fn(),
+      };
+      mockClient.api = vi.fn().mockReturnValue(mockApiChain);
+      registerTeamsTools(mockServer, mockGraphService, false);
+
+      const tool = mockServer.getTool("set_channel_message_reaction");
+      const result = await tool.handler({
+        teamId: "test-team-id",
+        channelId: "test-channel-id",
+        messageId: "msg-123",
+        reactionType: "like",
+      });
+
+      expect(mockClient.api).toHaveBeenCalledWith(
+        "/teams/test-team-id/channels/test-channel-id/messages/msg-123/setReaction"
+      );
+      expect(mockApiChain.post).toHaveBeenCalledWith({ reactionType: "like" });
+      expect(result.content[0].text).toBe("✅ Reaction like added to message msg-123.");
+    });
+
+    it("should set a reaction on a reply", async () => {
+      const mockApiChain = {
+        post: vi.fn().mockResolvedValue(undefined),
+        get: vi.fn(),
+      };
+      mockClient.api = vi.fn().mockReturnValue(mockApiChain);
+      registerTeamsTools(mockServer, mockGraphService, false);
+
+      const tool = mockServer.getTool("set_channel_message_reaction");
+      const result = await tool.handler({
+        teamId: "test-team-id",
+        channelId: "test-channel-id",
+        messageId: "msg-123",
+        reactionType: "👍",
+        replyId: "reply-456",
+      });
+
+      expect(mockClient.api).toHaveBeenCalledWith(
+        "/teams/test-team-id/channels/test-channel-id/messages/msg-123/replies/reply-456/setReaction"
+      );
+      expect(mockApiChain.post).toHaveBeenCalledWith({ reactionType: "👍" });
+      expect(result.content[0].text).toBe("✅ Reaction 👍 added to reply reply-456.");
+    });
+
+    it("should handle set reaction errors", async () => {
+      const mockApiChain = {
+        post: vi.fn().mockRejectedValue(new Error("Forbidden")),
+        get: vi.fn(),
+      };
+      mockClient.api = vi.fn().mockReturnValue(mockApiChain);
+      registerTeamsTools(mockServer, mockGraphService, false);
+
+      const tool = mockServer.getTool("set_channel_message_reaction");
+      const result = await tool.handler({
+        teamId: "test-team-id",
+        channelId: "test-channel-id",
+        messageId: "msg-123",
+        reactionType: "like",
+      });
+
+      expect(result.content[0].text).toBe("❌ Failed to set reaction: Forbidden");
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("unset_channel_message_reaction tool", () => {
+    it("should unset a reaction on a channel message", async () => {
+      const mockApiChain = {
+        post: vi.fn().mockResolvedValue(undefined),
+        get: vi.fn(),
+      };
+      mockClient.api = vi.fn().mockReturnValue(mockApiChain);
+      registerTeamsTools(mockServer, mockGraphService, false);
+
+      const tool = mockServer.getTool("unset_channel_message_reaction");
+      const result = await tool.handler({
+        teamId: "test-team-id",
+        channelId: "test-channel-id",
+        messageId: "msg-123",
+        reactionType: "like",
+      });
+
+      expect(mockClient.api).toHaveBeenCalledWith(
+        "/teams/test-team-id/channels/test-channel-id/messages/msg-123/unsetReaction"
+      );
+      expect(mockApiChain.post).toHaveBeenCalledWith({ reactionType: "like" });
+      expect(result.content[0].text).toBe("✅ Reaction like removed from message msg-123.");
+    });
+
+    it("should unset a reaction on a reply", async () => {
+      const mockApiChain = {
+        post: vi.fn().mockResolvedValue(undefined),
+        get: vi.fn(),
+      };
+      mockClient.api = vi.fn().mockReturnValue(mockApiChain);
+      registerTeamsTools(mockServer, mockGraphService, false);
+
+      const tool = mockServer.getTool("unset_channel_message_reaction");
+      const result = await tool.handler({
+        teamId: "test-team-id",
+        channelId: "test-channel-id",
+        messageId: "msg-123",
+        reactionType: "heart",
+        replyId: "reply-456",
+      });
+
+      expect(mockClient.api).toHaveBeenCalledWith(
+        "/teams/test-team-id/channels/test-channel-id/messages/msg-123/replies/reply-456/unsetReaction"
+      );
+      expect(mockApiChain.post).toHaveBeenCalledWith({ reactionType: "heart" });
+      expect(result.content[0].text).toBe("✅ Reaction heart removed from reply reply-456.");
+    });
+
+    it("should handle unset reaction errors", async () => {
+      const mockApiChain = {
+        post: vi.fn().mockRejectedValue(new Error("Not found")),
+        get: vi.fn(),
+      };
+      mockClient.api = vi.fn().mockReturnValue(mockApiChain);
+      registerTeamsTools(mockServer, mockGraphService, false);
+
+      const tool = mockServer.getTool("unset_channel_message_reaction");
+      const result = await tool.handler({
+        teamId: "test-team-id",
+        channelId: "test-channel-id",
+        messageId: "msg-123",
+        reactionType: "like",
+      });
+
+      expect(result.content[0].text).toBe("❌ Failed to unset reaction: Not found");
       expect(result.isError).toBe(true);
     });
   });

--- a/src/tools/chats.ts
+++ b/src/tools/chats.ts
@@ -279,7 +279,6 @@ export function registerChatTools(
             (r: ChatMessageReaction): ReactionSummary => ({
               reactionType: r.reactionType,
               displayName: r.displayName,
-              user: r.user?.user?.displayName,
               createdDateTime: r.createdDateTime,
             })
           ),

--- a/src/tools/chats.ts
+++ b/src/tools/chats.ts
@@ -279,6 +279,7 @@ export function registerChatTools(
             (r: ChatMessageReaction): ReactionSummary => ({
               reactionType: r.reactionType,
               displayName: r.displayName,
+              user: r.user?.user?.displayName,
               createdDateTime: r.createdDateTime,
             })
           ),

--- a/src/tools/chats.ts
+++ b/src/tools/chats.ts
@@ -4,11 +4,13 @@ import type { GraphService } from "../services/graph.js";
 import type {
   Chat,
   ChatMessage,
+  ChatMessageReaction,
   ChatSummary,
   ConversationMember,
   CreateChatPayload,
   GraphApiResponse,
   MessageSummary,
+  ReactionSummary,
   User,
 } from "../types/graph.js";
 import { extractAttachmentSummaries } from "../utils/attachments.js";
@@ -273,6 +275,13 @@ export function registerChatTools(
           from: message.from?.user?.displayName,
           createdDateTime: message.createdDateTime,
           attachments: extractAttachmentSummaries(message.attachments),
+          reactions: message.reactions?.map(
+            (r: ChatMessageReaction): ReactionSummary => ({
+              reactionType: r.reactionType,
+              displayName: r.displayName,
+              createdDateTime: r.createdDateTime,
+            })
+          ),
         }));
 
         return {
@@ -854,6 +863,94 @@ export function registerChatTools(
             {
               type: "text" as const,
               text: `❌ Failed to delete message: ${errorMessage}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // Set a reaction on a chat message
+  server.tool(
+    "set_chat_message_reaction",
+    "Add a reaction to a message in a chat conversation. Supports Unicode emoji characters and named reactions (like, angry, sad, laugh, heart, surprised).",
+    {
+      chatId: z.string().describe("Chat ID"),
+      messageId: z.string().describe("Message ID to react to"),
+      reactionType: z
+        .string()
+        .describe(
+          'Reaction type - Unicode emoji (e.g., "👍") or named reaction (e.g., "like", "heart")'
+        ),
+    },
+    async ({ chatId, messageId, reactionType }) => {
+      try {
+        const client = await graphService.getClient();
+
+        await client
+          .api(`/chats/${chatId}/messages/${messageId}/setReaction`)
+          .post({ reactionType });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `✅ Reaction ${reactionType} added to message ${messageId}.`,
+            },
+          ],
+        };
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `❌ Failed to set reaction: ${errorMessage}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // Unset a reaction on a chat message
+  server.tool(
+    "unset_chat_message_reaction",
+    "Remove a reaction from a message in a chat conversation.",
+    {
+      chatId: z.string().describe("Chat ID"),
+      messageId: z.string().describe("Message ID to remove reaction from"),
+      reactionType: z
+        .string()
+        .describe(
+          'Reaction type to remove - Unicode emoji (e.g., "👍") or named reaction (e.g., "like", "heart")'
+        ),
+    },
+    async ({ chatId, messageId, reactionType }) => {
+      try {
+        const client = await graphService.getClient();
+
+        await client
+          .api(`/chats/${chatId}/messages/${messageId}/unsetReaction`)
+          .post({ reactionType });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `✅ Reaction ${reactionType} removed from message ${messageId}.`,
+            },
+          ],
+        };
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `❌ Failed to unset reaction: ${errorMessage}`,
             },
           ],
           isError: true,

--- a/src/tools/teams.ts
+++ b/src/tools/teams.ts
@@ -5,10 +5,12 @@ import type {
   Channel,
   ChannelSummary,
   ChatMessage,
+  ChatMessageReaction,
   ConversationMember,
   GraphApiResponse,
   MemberSummary,
   MessageSummary,
+  ReactionSummary,
   Team,
   TeamSummary,
 } from "../types/graph.js";
@@ -207,6 +209,13 @@ export function registerTeamsTools(
           createdDateTime: message.createdDateTime,
           importance: message.importance,
           attachments: extractAttachmentSummaries(message.attachments),
+          reactions: message.reactions?.map(
+            (r: ChatMessageReaction): ReactionSummary => ({
+              reactionType: r.reactionType,
+              displayName: r.displayName,
+              createdDateTime: r.createdDateTime,
+            })
+          ),
         }));
 
         // Sort messages by creation date (newest first) since API doesn't support orderby
@@ -520,6 +529,13 @@ export function registerTeamsTools(
           createdDateTime: reply.createdDateTime,
           importance: reply.importance,
           attachments: extractAttachmentSummaries(reply.attachments),
+          reactions: reply.reactions?.map(
+            (r: ChatMessageReaction): ReactionSummary => ({
+              reactionType: r.reactionType,
+              displayName: r.displayName,
+              createdDateTime: r.createdDateTime,
+            })
+          ),
         }));
 
         // Sort replies by creation date (oldest first for replies)
@@ -1300,6 +1316,113 @@ export function registerTeamsTools(
               {
                 type: "text" as const,
                 text: `❌ Failed to update channel message: ${errorMessage}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+      }
+    );
+
+  // Set a reaction on a channel message (write — skipped in read-only mode)
+  if (!readOnly)
+    server.tool(
+      "set_channel_message_reaction",
+      "Add a reaction to a message in a Teams channel. Supports Unicode emoji characters and named reactions (like, angry, sad, laugh, heart, surprised). Can also react to replies.",
+      {
+        teamId: z.string().describe("Team ID"),
+        channelId: z.string().describe("Channel ID"),
+        messageId: z.string().describe("Message ID to react to"),
+        reactionType: z
+          .string()
+          .describe(
+            'Reaction type - Unicode emoji (e.g., "👍") or named reaction (e.g., "like", "heart")'
+          ),
+        replyId: z.string().optional().describe("Reply ID if reacting to a reply (optional)"),
+      },
+      async ({ teamId, channelId, messageId, reactionType, replyId }) => {
+        try {
+          const client = await graphService.getClient();
+
+          const endpoint = replyId
+            ? `/teams/${teamId}/channels/${channelId}/messages/${messageId}/replies/${replyId}/setReaction`
+            : `/teams/${teamId}/channels/${channelId}/messages/${messageId}/setReaction`;
+
+          await client.api(endpoint).post({ reactionType });
+
+          const targetId = replyId || messageId;
+          const targetType = replyId ? "reply" : "message";
+
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `✅ Reaction ${reactionType} added to ${targetType} ${targetId}.`,
+              },
+            ],
+          };
+        } catch (error: unknown) {
+          const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `❌ Failed to set reaction: ${errorMessage}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+      }
+    );
+
+  // Unset a reaction on a channel message (write — skipped in read-only mode)
+  if (!readOnly)
+    server.tool(
+      "unset_channel_message_reaction",
+      "Remove a reaction from a message in a Teams channel. Can also remove reactions from replies.",
+      {
+        teamId: z.string().describe("Team ID"),
+        channelId: z.string().describe("Channel ID"),
+        messageId: z.string().describe("Message ID to remove reaction from"),
+        reactionType: z
+          .string()
+          .describe(
+            'Reaction type to remove - Unicode emoji (e.g., "👍") or named reaction (e.g., "like", "heart")'
+          ),
+        replyId: z
+          .string()
+          .optional()
+          .describe("Reply ID if removing reaction from a reply (optional)"),
+      },
+      async ({ teamId, channelId, messageId, reactionType, replyId }) => {
+        try {
+          const client = await graphService.getClient();
+
+          const endpoint = replyId
+            ? `/teams/${teamId}/channels/${channelId}/messages/${messageId}/replies/${replyId}/unsetReaction`
+            : `/teams/${teamId}/channels/${channelId}/messages/${messageId}/unsetReaction`;
+
+          await client.api(endpoint).post({ reactionType });
+
+          const targetId = replyId || messageId;
+          const targetType = replyId ? "reply" : "message";
+
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `✅ Reaction ${reactionType} removed from ${targetType} ${targetId}.`,
+              },
+            ],
+          };
+        } catch (error: unknown) {
+          const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `❌ Failed to unset reaction: ${errorMessage}`,
               },
             ],
             isError: true,

--- a/src/tools/teams.ts
+++ b/src/tools/teams.ts
@@ -213,6 +213,7 @@ export function registerTeamsTools(
             (r: ChatMessageReaction): ReactionSummary => ({
               reactionType: r.reactionType,
               displayName: r.displayName,
+              user: r.user?.user?.displayName,
               createdDateTime: r.createdDateTime,
             })
           ),
@@ -533,6 +534,7 @@ export function registerTeamsTools(
             (r: ChatMessageReaction): ReactionSummary => ({
               reactionType: r.reactionType,
               displayName: r.displayName,
+              user: r.user?.user?.displayName,
               createdDateTime: r.createdDateTime,
             })
           ),

--- a/src/tools/teams.ts
+++ b/src/tools/teams.ts
@@ -213,7 +213,6 @@ export function registerTeamsTools(
             (r: ChatMessageReaction): ReactionSummary => ({
               reactionType: r.reactionType,
               displayName: r.displayName,
-              user: r.user?.user?.displayName,
               createdDateTime: r.createdDateTime,
             })
           ),
@@ -534,7 +533,6 @@ export function registerTeamsTools(
             (r: ChatMessageReaction): ReactionSummary => ({
               reactionType: r.reactionType,
               displayName: r.displayName,
-              user: r.user?.user?.displayName,
               createdDateTime: r.createdDateTime,
             })
           ),

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -6,6 +6,7 @@ import type {
   ChatMessageAttachment,
   ChatMessageImportance,
   ChatMessageInfo,
+  ChatMessageReaction,
   ChatType,
   ConversationMember,
   NullableOption,
@@ -24,6 +25,7 @@ export type {
   Channel,
   ChatMessage,
   ChatMessageAttachment,
+  ChatMessageReaction,
   ConversationMember,
   TeamsAppInstallation,
   ChatMessageInfo,
@@ -93,6 +95,12 @@ export interface AttachmentSummary {
   thumbnailUrl?: string | undefined;
 }
 
+export interface ReactionSummary {
+  reactionType?: string | undefined;
+  displayName?: NullableOption<string> | undefined;
+  createdDateTime?: string | undefined;
+}
+
 export interface MessageSummary {
   id?: string | undefined;
   content?: NullableOption<string> | undefined;
@@ -100,6 +108,7 @@ export interface MessageSummary {
   createdDateTime?: NullableOption<string> | undefined;
   importance?: ChatMessageImportance | undefined;
   attachments?: AttachmentSummary[] | undefined;
+  reactions?: ReactionSummary[] | undefined;
 }
 
 export interface MemberSummary {

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -98,6 +98,7 @@ export interface AttachmentSummary {
 export interface ReactionSummary {
   reactionType?: string | undefined;
   displayName?: NullableOption<string> | undefined;
+  user?: NullableOption<string> | undefined;
   createdDateTime?: string | undefined;
 }
 

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -98,7 +98,6 @@ export interface AttachmentSummary {
 export interface ReactionSummary {
   reactionType?: string | undefined;
   displayName?: NullableOption<string> | undefined;
-  user?: NullableOption<string> | undefined;
   createdDateTime?: string | undefined;
 }
 


### PR DESCRIPTION
## Summary
Incorporates #72 by @ikstewa with merge conflicts resolved.

- Reactions included in `MessageSummary` responses for chat and channel messages
- 4 new tools: `set_chat_message_reaction`, `unset_chat_message_reaction`, `set_channel_message_reaction`, `unset_channel_message_reaction`
- No new OAuth scopes required

## Conflict resolution
- `src/types/graph.ts`: added `ChatMessageReaction` to the alphabetically sorted re-export list after main reorganized exports

## Test plan
- [x] All 367 tests pass
- [x] TypeScript compiles cleanly

Closes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to add and remove emoji reactions to messages in chats
  * Added ability to add and remove emoji reactions to messages in Teams channels and replies
  * Message retrieval now includes reaction metadata with reaction types and creator information when available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->