### PR TITLE
fix(chats): use 'owner' role for all members in create_chat

### DIFF
--- a/src/tools/__tests__/chats.test.ts
+++ b/src/tools/__tests__/chats.test.ts
@@ -1086,12 +1086,12 @@ describe("Chat Tools", () => {
           {
             "@odata.type": "#microsoft.graph.aadUserConversationMember",
             user: { id: "user1" },
-            roles: ["member"],
+            roles: ["owner"],
           },
           {
             "@odata.type": "#microsoft.graph.aadUserConversationMember",
             user: { id: "user2" },
-            roles: ["member"],
+            roles: ["owner"],
           },
         ],
       });

--- a/src/tools/chats.ts
+++ b/src/tools/chats.ts
@@ -702,8 +702,14 @@ export function registerChatTools(
           } as ConversationMember,
         ];
 
-        // Add other users
-        // For oneOnOne chats, all members must have "owner" role
+        // Add other users.
+        // The Graph API requires "owner" for all members in both oneOnOne and
+        // group chats created via POST /chats. Passing "member" results in
+        // `The passed-in role 'member' is not supported.` (Graph validates at
+        // creation time — `member` is only a valid role for participants
+        // *added later* via POST /chats/{id}/members, not at creation.)
+        // See https://learn.microsoft.com/en-us/graph/api/chat-post — every
+        // example, group or oneOnOne, uses `roles: ["owner"]`.
         const isOneOnOne = userEmails.length === 1;
         for (const email of userEmails) {
           const user = (await client.api(`/users/${email}`).get()) as User;
@@ -712,7 +718,7 @@ export function registerChatTools(
             user: {
               id: user?.id,
             },
-            roles: [isOneOnOne ? "owner" : "member"],
+            roles: ["owner"],
           } as ConversationMember);
         }
 


### PR DESCRIPTION
## Problem

Calling `create_chat` with 2+ `userEmails` always fails with:

```
❌ Error: The passed-in role 'member' is not supported.
```

The Microsoft Graph `POST /chats` endpoint rejects `roles: ["member"]` for any participant **at creation time**. The `member` role is only valid when adding participants *later* via `POST /chats/{id}/members`.

At creation, every participant — for both `oneOnOne` and `group` chats — must have `roles: ["owner"]`. The only other allowed value at creation is `"guest"`, used for cross-cloud external users.

This is documented implicitly in the Graph API reference: every example on the [Create chat docs](https://learn.microsoft.com/en-us/graph/api/chat-post) (group or oneOnOne) uses `roles: ["owner"]` for every member.

## Root cause

[`src/tools/chats.ts`](https://github.com/floriscornel/teams-mcp/blob/main/src/tools/chats.ts#L715) currently does:

```ts
const isOneOnOne = userEmails.length === 1;
for (const email of userEmails) {
  const user = (await client.api(`/users/${email}`).get()) as User;
  members.push({
    "@odata.type": "#microsoft.graph.aadUserConversationMember",
    user: { id: user?.id },
    roles: [isOneOnOne ? "owner" : "member"],   // ← rejected for groups
  } as ConversationMember);
}
```

The original intent (judging by the comment "For oneOnOne chats, all members must have 'owner' role") seems to be that `member` is acceptable for groups — but Graph rejects it.

## Fix

Always use `roles: ["owner"]` for every member at creation. Comment updated to explain why and link to the docs.

```diff
-        // Add other users
-        // For oneOnOne chats, all members must have "owner" role
+        // Add other users.
+        // The Graph API requires "owner" for all members in both oneOnOne and
+        // group chats created via POST /chats. Passing "member" results in
+        // `The passed-in role 'member' is not supported.` (Graph validates at
+        // creation time — `member` is only a valid role for participants
+        // *added later* via POST /chats/{id}/members, not at creation.)
+        // See https://learn.microsoft.com/en-us/graph/api/chat-post — every
+        // example, group or oneOnOne, uses `roles: ["owner"]`.
         const isOneOnOne = userEmails.length === 1;
         for (const email of userEmails) {
           const user = (await client.api(`/users/${email}`).get()) as User;
           members.push({
             "@odata.type": "#microsoft.graph.aadUserConversationMember",
             user: { id: user?.id },
-            roles: [isOneOnOne ? "owner" : "member"],
+            roles: ["owner"],
           } as ConversationMember);
         }
```

The `isOneOnOne` flag is left in place because it's still used right after to set `chatType` and to gate the `topic` field.

## Reproduction (before fix)

```ts
await createChatHandler({
  userEmails: ["alice@contoso.com", "bob@contoso.com"],
  topic: "Test group",
});
// → ❌ Error: The passed-in role 'member' is not supported.
```

After this PR, the same call returns `✅ Chat created successfully. Chat ID: ...`. Verified against a live Azure AD tenant.

## Tests

`src/tools/__tests__/chats.test.ts` had two `roles: ["member"]` expectations in the group-chat creation test — updated to `roles: ["owner"]` to match the corrected behavior. Full suite passes (`vitest run src/tools/__tests__/chats.test.ts` → 59 / 59).

## Risk

Low. The change is a strict simplification (one branch removed) and is required for `create_chat` to work at all for group chats. No behavior change for callers that were working (oneOnOne already used `owner`). No new permissions required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat member role assignment during creation to ensure proper chat initialization across all chat types.

* **Tests**
  * Updated test expectations for member role assignments in chat creation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->