### PR TITLE
fix(chats): use 'owner' role for group chat members + add add_chat_member tool

### DIFF
--- a/src/tools/__tests__/chats.test.ts
+++ b/src/tools/__tests__/chats.test.ts
@@ -39,7 +39,7 @@ describe("Chat Tools", () => {
     it("should register all chat tools", () => {
       registerChatTools(mockServer, mockGraphService, false);
 
-      expect(mockServer.registerTool).toHaveBeenCalledTimes(10);
+      expect(mockServer.registerTool).toHaveBeenCalledTimes(11);
       expect(mockServer.registerTool).toHaveBeenCalledWith(
         "list_chats",
         expect.any(Object),
@@ -57,6 +57,11 @@ describe("Chat Tools", () => {
       );
       expect(mockServer.registerTool).toHaveBeenCalledWith(
         "create_chat",
+        expect.any(Object),
+        expect.any(Function)
+      );
+      expect(mockServer.registerTool).toHaveBeenCalledWith(
+        "add_chat_member",
         expect.any(Object),
         expect.any(Function)
       );
@@ -1086,12 +1091,12 @@ describe("Chat Tools", () => {
           {
             "@odata.type": "#microsoft.graph.aadUserConversationMember",
             user: { id: "user1" },
-            roles: ["member"],
+            roles: ["owner"],
           },
           {
             "@odata.type": "#microsoft.graph.aadUserConversationMember",
             user: { id: "user2" },
-            roles: ["member"],
+            roles: ["owner"],
           },
         ],
       });
@@ -1156,6 +1161,63 @@ describe("Chat Tools", () => {
       });
 
       expect(result.content[0].text).toBe("❌ Error: Failed to create chat");
+    });
+  });
+
+  describe("add_chat_member", () => {
+    let addChatMemberHandler: (args?: any) => Promise<any>;
+
+    beforeEach(() => {
+      registerChatTools(mockServer, mockGraphService, false);
+      const call = vi
+        .mocked(mockServer.registerTool)
+        .mock.calls.find(([name]) => name === "add_chat_member");
+      addChatMemberHandler = call?.[2] as unknown as (args: any) => Promise<any>;
+    });
+
+    it("should add multiple members and report per-user success", async () => {
+      const mockApiChain = {
+        get: vi.fn().mockResolvedValueOnce({ id: "user1" }).mockResolvedValueOnce({ id: "user2" }),
+        post: vi.fn().mockResolvedValue({}),
+      };
+      mockClient.api = vi.fn().mockReturnValue(mockApiChain);
+
+      const result = await addChatMemberHandler({
+        chatId: "19:abc@thread.v2",
+        userEmails: ["a@example.com", "b@example.com"],
+      });
+
+      expect(mockApiChain.post).toHaveBeenCalledWith({
+        "@odata.type": "#microsoft.graph.aadUserConversationMember",
+        roles: ["owner"],
+        "user@odata.bind": "https://graph.microsoft.com/v1.0/users('user1')",
+      });
+      expect(mockApiChain.post).toHaveBeenCalledWith({
+        "@odata.type": "#microsoft.graph.aadUserConversationMember",
+        roles: ["owner"],
+        "user@odata.bind": "https://graph.microsoft.com/v1.0/users('user2')",
+      });
+      expect(result.content[0].text).toContain("✅ a@example.com: added");
+      expect(result.content[0].text).toContain("✅ b@example.com: added");
+    });
+
+    it("should continue on per-user failure and report it", async () => {
+      const mockApiChain = {
+        get: vi
+          .fn()
+          .mockRejectedValueOnce(new Error("User not found"))
+          .mockResolvedValueOnce({ id: "user2" }),
+        post: vi.fn().mockResolvedValue({}),
+      };
+      mockClient.api = vi.fn().mockReturnValue(mockApiChain);
+
+      const result = await addChatMemberHandler({
+        chatId: "19:abc@thread.v2",
+        userEmails: ["bad@example.com", "ok@example.com"],
+      });
+
+      expect(result.content[0].text).toContain("❌ bad@example.com: User not found");
+      expect(result.content[0].text).toContain("✅ ok@example.com: added");
     });
   });
 

--- a/src/tools/chats.ts
+++ b/src/tools/chats.ts
@@ -702,8 +702,11 @@ export function registerChatTools(
           } as ConversationMember,
         ];
 
-        // Add other users
-        // For oneOnOne chats, all members must have "owner" role
+        // Add other users.
+        // Microsoft Graph requires roles=["owner"] for both oneOnOne and group
+        // chat members in the delegated-permission flow; passing ["member"]
+        // returns "The passed-in role 'member' is not supported."
+        // See: https://learn.microsoft.com/en-us/graph/api/chat-post
         const isOneOnOne = userEmails.length === 1;
         for (const email of userEmails) {
           const user = (await client.api(`/users/${email}`).get()) as User;
@@ -712,7 +715,7 @@ export function registerChatTools(
             user: {
               id: user?.id,
             },
-            roles: [isOneOnOne ? "owner" : "member"],
+            roles: ["owner"],
           } as ConversationMember);
         }
 
@@ -732,6 +735,72 @@ export function registerChatTools(
             {
               type: "text",
               text: `✅ Chat created successfully. Chat ID: ${newChat?.id}`,
+            },
+          ],
+        };
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
+        return {
+          content: [
+            {
+              type: "text",
+              text: `❌ Error: ${errorMessage}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  // Add one or more members to an existing group chat
+  server.registerTool(
+    "add_chat_member",
+    {
+      title: "Add Chat Member",
+      description:
+        "Add one or more users to an existing group chat by email. Returns a per-user success/failure report so partial failures (e.g. unknown email) don't abort the batch.",
+      inputSchema: {
+        chatId: z.string().describe("Chat ID (e.g. 19:abc...@thread.v2)"),
+        userEmails: z
+          .array(z.string())
+          .describe("Array of user email addresses to add to the chat"),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async ({ chatId, userEmails }) => {
+      try {
+        const client = await graphService.getClient();
+        const results: string[] = [];
+
+        for (const email of userEmails) {
+          try {
+            const user = (await client.api(`/users/${email}`).get()) as User;
+            if (!user?.id) {
+              results.push(`❌ ${email}: not found in tenant`);
+              continue;
+            }
+            await client.api(`/chats/${chatId}/members`).post({
+              "@odata.type": "#microsoft.graph.aadUserConversationMember",
+              roles: ["owner"],
+              "user@odata.bind": `https://graph.microsoft.com/v1.0/users('${user.id}')`,
+            });
+            results.push(`✅ ${email}: added`);
+          } catch (err: unknown) {
+            const m = err instanceof Error ? err.message : String(err);
+            results.push(`❌ ${email}: ${m}`);
+          }
+        }
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `add_chat_member to ${chatId}\n\n${results.join("\n")}`,
             },
           ],
         };


### PR DESCRIPTION
## Summary

Two related fixes to chat-creation/management in the delegated-permission flow:

- **`create_chat` role fix**: Microsoft Graph rejects `roles: ["member"]` in the delegated flow with `The passed-in role 'member' is not supported.` Both `oneOnOne` and `group` chats must be created with `roles: ["owner"]` for non-creator members. Without this fix, every multi-user `create_chat` call fails. ([Graph reference](https://learn.microsoft.com/en-us/graph/api/chat-post))

- **New `add_chat_member` tool**: previously there was no way to add members to an existing chat through this MCP server — the only path was delete-and-recreate. The new tool takes a `chatId` + array of emails and returns a per-user success/failure report, so one unknown email doesn't abort the batch. Gated behind the same `readOnly` check as the other write tools.

## Why this matters

These bugs surface as soon as you try to use `create_chat` for any group chat with more than one other person — the call returns the misleading `member` role error and you can't recover without an `add_chat_member` capability either. Hit this in production rolling out a HEAT internal tooling chat for ~14 colleagues; had to local-patch the installed package to ship.

## Test plan

- [x] `npm run lint` — passes
- [x] `npm run build` — passes
- [x] `npm test` — 369 passed / 17 skipped (was 368 / 17)
- [x] Updated the existing group-chat `create_chat` assertion to expect `roles: ["owner"]`
- [x] Added a new `describe("add_chat_member", ...)` block covering happy path + per-user error path
- [x] Manually verified end-to-end: created a 16-member group chat with `create_chat`, then added 14 additional members via `add_chat_member` against a real M365 tenant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to add members to existing group chats by email address, with support for multiple users and partial failure handling.
  * Standardized group chat member roles to owner status during creation.

* **Tests**
  * Expanded test coverage for chat member operations including per-user success/failure reporting and member payload validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->