### PR TITLE
feat: Interactive auth-code flow with env-driven Entra config

### DIFF
--- a/ENTRA_SETUP.md
+++ b/ENTRA_SETUP.md
@@ -6,9 +6,24 @@ by tenants which enable the Microsoft-managed Conditional Access policy
 *"Block device code flow"* (on by default for tenants created after Microsoft's
 2025 security baseline rollout).
 
-The interactive flow requires your **own Entra app registration**, because the upstream
-default (Microsoft Graph CLI app, `14d82eec-204b-4c2f-b7e8-296a70dab67e`) does not
-have `http://localhost` registered as a public-client redirect URI in your tenant.
+The interactive flow requires an Entra app registration **in your tenant**, because the
+upstream default (Microsoft Graph CLI app, `14d82eec-204b-4c2f-b7e8-296a70dab67e`) does
+not have `http://localhost` registered as a public-client redirect URI in your tenant.
+
+## Which path applies to you?
+
+The app registration is **per tenant, not per user** — one registration serves the whole
+organisation. Tokens are user-delegated and stored per user (`~/.teams-mcp-token-cache.json`),
+so every signed-in user only sees their own Teams data.
+
+- **Path A — first person in the tenant / admin:** no existing registration yet. Follow
+  sections 1 → 5 below to create it, grant admin consent, and authenticate.
+- **Path B — your org already has a teams-mcp app registration:** ask whoever set it up
+  (or your Entra admin) for the **client ID** and **tenant ID**. Skip sections 1 – 3 and
+  jump straight to [section 4 (Authenticate)](#4-authenticate).
+
+The client ID is **not a secret** — it's safe to share internally (Teams/Slack/wiki),
+but don't publish it to public GitHub.
 
 ## 1. Register the app
 
@@ -70,7 +85,8 @@ the upstream default `/common` will reject sign-in with `AADSTS50194`.
 
 ## 4. Authenticate
 
-From the cloned/built fork:
+You need the **client ID** and **tenant ID** from section 3 (or from your admin if you
+are on Path B). From the cloned/built fork:
 
 ```bash
 TEAMS_MCP_CLIENT_ID=<your-client-id> \

--- a/ENTRA_SETUP.md
+++ b/ENTRA_SETUP.md
@@ -16,7 +16,7 @@ Microsoft Entra admin center → **Identity → Applications → App registratio
 
 | Field                 | Value                                                          |
 |-----------------------|----------------------------------------------------------------|
-| Name                  | `teams-mcp` (or org-specific, e.g. `summit-teams-mcp`)         |
+| Name                  | `teams-mcp` (or org-specific, e.g. `yourcompany-teams-mcp`)    |
 | Supported accounts    | **Single tenant only** (`Accounts in this organizational directory only`) |
 | Redirect URI platform | **Public client/native (mobile & desktop)**                    |
 | Redirect URI value    | `http://localhost` *(no port — Entra allows any loopback port at runtime per RFC 8252)* |

--- a/ENTRA_SETUP.md
+++ b/ENTRA_SETUP.md
@@ -3,8 +3,7 @@
 This fork adds an `authenticate --interactive` flow that uses **OAuth auth-code + PKCE
 with a loopback redirect**, sidestepping the upstream device-code flow that gets blocked
 by tenants which enable the Microsoft-managed Conditional Access policy
-*"Block device code flow"* (on by default for tenants created after Microsoft's
-2025 security baseline rollout).
+*"Block device code flow"* (often enforced by tenant Conditional Access policy).
 
 The interactive flow requires an Entra app registration **in your tenant**, because the
 upstream default (Microsoft Graph CLI app, `14d82eec-204b-4c2f-b7e8-296a70dab67e`) does

--- a/ENTRA_SETUP.md
+++ b/ENTRA_SETUP.md
@@ -1,0 +1,127 @@
+# Entra ID setup for teams-mcp (interactive auth-code flow)
+
+This fork adds an `authenticate --interactive` flow that uses **OAuth auth-code + PKCE
+with a loopback redirect**, sidestepping the upstream device-code flow that gets blocked
+by tenants which enable the Microsoft-managed Conditional Access policy
+*"Block device code flow"* (on by default for tenants created after Microsoft's
+2025 security baseline rollout).
+
+The interactive flow requires your **own Entra app registration**, because the upstream
+default (Microsoft Graph CLI app, `14d82eec-204b-4c2f-b7e8-296a70dab67e`) does not
+have `http://localhost` registered as a public-client redirect URI in your tenant.
+
+## 1. Register the app
+
+Microsoft Entra admin center → **Identity → Applications → App registrations → New registration**
+
+| Field                 | Value                                                          |
+|-----------------------|----------------------------------------------------------------|
+| Name                  | `teams-mcp` (or org-specific, e.g. `summit-teams-mcp`)         |
+| Supported accounts    | **Single tenant only** (`Accounts in this organizational directory only`) |
+| Redirect URI platform | **Public client/native (mobile & desktop)**                    |
+| Redirect URI value    | `http://localhost` *(no port — Entra allows any loopback port at runtime per RFC 8252)* |
+
+> If the new registration UI defaulted to **Web** platform, fix it after creation:
+> *Authentication* blade → delete the Web redirect URI → **Add a platform** → *Mobile and
+> desktop applications* → `http://localhost`.
+
+After creation, on the **Authentication** blade → **Settings** tab → confirm
+**"Allow public client flows"** is **Enabled**. MSAL will refuse the flow otherwise.
+
+## 2. Configure API permissions
+
+**API permissions** blade → **Add a permission** → **Microsoft Graph** → **Delegated permissions**.
+
+Required for full functionality:
+
+| Permission                              | Why                                                |
+|-----------------------------------------|----------------------------------------------------|
+| `User.Read`                             | Read signed-in user profile (auth status check)    |
+| `User.ReadBasic.All`                    | Resolve users referenced in chats / messages       |
+| `Team.ReadBasic.All`                    | List teams, resolve team ids                       |
+| `Channel.ReadBasic.All`                 | List channels                                      |
+| `ChannelMessage.Read.All`               | Read channel messages (admin-consent required)     |
+| `ChannelMessage.Send`                   | Post replies                                       |
+| `ChannelMessage.ReadWrite`              | Edit / react / unreact on channel messages         |
+| `Chat.ReadWrite`                        | Read + send 1:1 / group chat messages              |
+| `TeamMember.Read.All`                   | Resolve team member identities                     |
+| `Files.ReadWrite.All`                   | Upload attachments to channels / chats             |
+| `TeamsAppInstallation.ReadWriteSelfForChat` *(optional)* | Allow the app to install itself in a chat (some attachment flows) |
+
+A few of these (`ChannelMessage.Read.All`, `TeamsAppInstallation.*`) are flagged
+**"Admin consent required"**. After adding, click **Grant admin consent for
+\<your tenant\>** at the top of the permissions list. All rows should show
+**Status: Granted for \<your tenant\>** (green check).
+
+For a read-only deployment (start MCP with `--read-only`), the minimum set is
+`User.Read`, `User.ReadBasic.All`, `Team.ReadBasic.All`, `Channel.ReadBasic.All`,
+`ChannelMessage.Read.All`, `TeamMember.Read.All`, `Chat.Read`.
+
+## 3. Note the IDs
+
+**Overview** blade → copy:
+
+- **Application (client) ID** → set as `TEAMS_MCP_CLIENT_ID`
+- **Directory (tenant) ID** → use in `TEAMS_MCP_AUTHORITY` =
+  `https://login.microsoftonline.com/<tenant-id>`
+
+Single-tenant authority is **required** when the app registration is single-tenant;
+the upstream default `/common` will reject sign-in with `AADSTS50194`.
+
+## 4. Authenticate
+
+From the cloned/built fork:
+
+```bash
+TEAMS_MCP_CLIENT_ID=<your-client-id> \
+TEAMS_MCP_AUTHORITY=https://login.microsoftonline.com/<your-tenant-id> \
+  node dist/index.js authenticate --interactive
+```
+
+A browser tab opens against `login.microsoftonline.com`, you sign in (passing
+Conditional Access naturally because the flow is interactive + carries device
+identity), and the redirect lands on `http://localhost:<ephemeral-port>` where
+MSAL's loopback listener exchanges the code for a token.
+
+The refresh token is cached at `~/.teams-mcp-token-cache.json`. The MCP server
+re-uses this cache silently on every start, refreshing access tokens as they
+expire — no further sign-in required until the refresh token's lifetime ends
+(typically 90 days).
+
+## 5. Wire into Claude Code / MCP client
+
+Edit `~/.claude.json` (or your MCP client's config):
+
+```json
+{
+  "mcpServers": {
+    "teams-mcp": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["/absolute/path/to/teams-mcp/dist/index.js"],
+      "env": {
+        "TEAMS_MCP_CLIENT_ID": "<your-client-id>",
+        "TEAMS_MCP_AUTHORITY": "https://login.microsoftonline.com/<your-tenant-id>"
+      }
+    }
+  }
+}
+```
+
+`AUTH_TOKEN=<jwt>` is still supported and takes priority over the cache.
+
+## Troubleshooting
+
+- **`AADSTS65001 / consent required`** — admin hasn't consented to the
+  permissions, or you added a new permission after the last consent. Re-run
+  *Grant admin consent* in the Entra portal.
+- **`AADSTS50194 / not configured as multi-tenant`** — you set
+  `TEAMS_MCP_AUTHORITY` to `/common` but the app is single-tenant. Use the
+  tenant-specific authority `https://login.microsoftonline.com/<tenant-id>`.
+- **`AADSTS530032 / blocked by Conditional Access`** — the interactive flow
+  is still being blocked. Check the CA report-only / blocking policies on the
+  user; consider adding the user to an exclusion group or enrolling the device
+  in Intune.
+- **Browser shows mojibake on the success page** — clear the token cache
+  (`teams-mcp logout`) and rebuild; the success template was fixed to declare
+  UTF-8 charset.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@azure/identity": "^4.13.1",
         "@azure/identity-cache-persistence": "^1.2.0",
+        "@azure/msal-node": "^5.1.1",
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@microsoft/microsoft-graph-types": "^2.43.1",
         "@modelcontextprotocol/sdk": "^1.28.0",
@@ -20,6 +21,7 @@
         "dompurify": "^3.3.3",
         "jsdom": "^29.0.1",
         "marked": "^17.0.5",
+        "open": "^10.2.0",
         "turndown": "^7.2.2",
         "turndown-plugin-gfm": "^1.0.2",
         "zod": "^4.3.6"
@@ -449,9 +451,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -469,9 +468,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -489,9 +485,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -509,9 +502,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -702,38 +692,35 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1198,9 +1185,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1423,9 +1410,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1467,9 +1454,9 @@
       "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1477,9 +1464,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
       "cpu": [
         "arm64"
       ],
@@ -1494,9 +1481,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
       "cpu": [
         "arm64"
       ],
@@ -1511,9 +1498,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
       "cpu": [
         "x64"
       ],
@@ -1528,9 +1515,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
       "cpu": [
         "x64"
       ],
@@ -1545,9 +1532,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
       "cpu": [
         "arm"
       ],
@@ -1562,16 +1549,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1582,16 +1566,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1602,16 +1583,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1622,16 +1600,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1642,16 +1617,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1662,16 +1634,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1682,9 +1651,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
       "cpu": [
         "arm64"
       ],
@@ -1699,9 +1668,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
       "cpu": [
         "wasm32"
       ],
@@ -1709,16 +1678,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
       "cpu": [
         "arm64"
       ],
@@ -1733,9 +1704,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
       "cpu": [
         "x64"
       ],
@@ -1750,9 +1721,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1805,9 +1776,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2638,9 +2609,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
+      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -2910,12 +2881,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -2934,9 +2905,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -3166,9 +3137,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
-      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "version": "4.12.19",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
+      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3288,9 +3259,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3711,9 +3682,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3735,9 +3703,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3759,9 +3724,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3783,9 +3745,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4106,9 +4065,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -4324,9 +4283,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -4526,14 +4485,14 @@
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.130.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -4542,21 +4501,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.0.1",
+        "@rolldown/binding-darwin-arm64": "1.0.1",
+        "@rolldown/binding-darwin-x64": "1.0.1",
+        "@rolldown/binding-freebsd-x64": "1.0.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
+        "@rolldown/binding-linux-arm64-musl": "1.0.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-musl": "1.0.1",
+        "@rolldown/binding-openharmony-arm64": "1.0.1",
+        "@rolldown/binding-wasm32-wasi": "1.0.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
+        "@rolldown/binding-win32-x64-msvc": "1.0.1"
       }
     },
     "node_modules/router": {
@@ -5037,14 +4996,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -5280,17 +5239,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
-      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.1",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -5306,8 +5265,8 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "@azure/identity": "^4.13.1",
     "@azure/identity-cache-persistence": "^1.2.0",
+    "@azure/msal-node": "^5.1.1",
     "@microsoft/microsoft-graph-client": "^3.0.7",
     "@microsoft/microsoft-graph-types": "^2.43.1",
     "@modelcontextprotocol/sdk": "^1.28.0",
@@ -63,6 +64,7 @@
     "dompurify": "^3.3.3",
     "jsdom": "^29.0.1",
     "marked": "^17.0.5",
+    "open": "^10.2.0",
     "turndown": "^7.2.2",
     "turndown-plugin-gfm": "^1.0.2",
     "zod": "^4.3.6"

--- a/src/__tests__/msal-cache.test.ts
+++ b/src/__tests__/msal-cache.test.ts
@@ -7,6 +7,7 @@ vi.mock("node:fs", () => ({
   promises: {
     readFile: vi.fn(),
     writeFile: vi.fn(),
+    chmod: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -102,7 +103,10 @@ describe("MSAL Cache Plugin", () => {
       await cachePlugin.afterCacheAccess(cacheContext);
 
       expect(serializeMock).toHaveBeenCalled();
-      expect(fs.writeFile).toHaveBeenCalledWith(CACHE_PATH, mockSerializedData, "utf8");
+      expect(fs.writeFile).toHaveBeenCalledWith(CACHE_PATH, mockSerializedData, {
+        encoding: "utf8",
+        mode: 0o600,
+      });
     });
 
     it("should not write cache data when cache has not changed", async () => {
@@ -142,7 +146,10 @@ describe("MSAL Cache Plugin", () => {
       await cachePlugin.afterCacheAccess(cacheContext);
 
       expect(serializeMock).toHaveBeenCalled();
-      expect(fs.writeFile).toHaveBeenCalledWith(CACHE_PATH, mockSerializedData, "utf8");
+      expect(fs.writeFile).toHaveBeenCalledWith(CACHE_PATH, mockSerializedData, {
+        encoding: "utf8",
+        mode: 0o600,
+      });
       expect(consoleErrorSpy).toHaveBeenCalledWith("Warning: Could not write token cache:", error);
 
       consoleErrorSpy.mockRestore();

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,13 @@
+// Default Microsoft Graph CLI app (multi-tenant public client).
+// Override with TEAMS_MCP_CLIENT_ID / TEAMS_MCP_AUTHORITY to use a custom Entra app
+// registration — required for tenants that block device-code flow via Conditional Access.
+const DEFAULT_CLIENT_ID = "14d82eec-204b-4c2f-b7e8-296a70dab67e";
+const DEFAULT_AUTHORITY = "https://login.microsoftonline.com/common";
+
+export function getClientId(): string {
+  return process.env.TEAMS_MCP_CLIENT_ID || DEFAULT_CLIENT_ID;
+}
+
+export function getAuthority(): string {
+  return process.env.TEAMS_MCP_AUTHORITY || DEFAULT_AUTHORITY;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,10 +4,12 @@
 const DEFAULT_CLIENT_ID = "14d82eec-204b-4c2f-b7e8-296a70dab67e";
 const DEFAULT_AUTHORITY = "https://login.microsoftonline.com/common";
 
+/** Entra app (client) ID — env override or Graph CLI default. */
 export function getClientId(): string {
   return process.env.TEAMS_MCP_CLIENT_ID || DEFAULT_CLIENT_ID;
 }
 
+/** OAuth authority URL — env override or `/common` default. */
 export function getAuthority(): string {
   return process.env.TEAMS_MCP_AUTHORITY || DEFAULT_AUTHORITY;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ async function readAuthInfo(): Promise<Record<string, unknown> | undefined> {
   }
 }
 
+/** Persist auth result metadata (account, scopes, expiry) with owner-only perms. */
 async function saveAuthInfo(result: AuthenticationResult, clientId: string): Promise<void> {
   const authInfo = {
     clientId,
@@ -63,6 +64,7 @@ async function saveAuthInfo(result: AuthenticationResult, clientId: string): Pro
   }
 }
 
+/** Print uniform success banner after either auth flow completes. */
 function reportAuthSuccess(
   result: AuthenticationResult,
   modeLabel: string,
@@ -76,6 +78,7 @@ function reportAuthSuccess(
   console.log("🔄 Refresh token cached for automatic renewal");
 }
 
+/** Map common AADSTS error codes to actionable messages, then exit non-zero. */
 function reportAuthError(error: unknown): never {
   const errorMessage = error instanceof Error ? error.message : String(error);
   if (errorMessage.includes("AADSTS50020")) {
@@ -93,7 +96,7 @@ function reportAuthError(error: unknown): never {
   process.exit(1);
 }
 
-// Authentication functions
+/** Device-code flow — prints user code + URL, polls until completion. */
 async function authenticate(readOnly: boolean) {
   const scopes = readOnly ? READ_ONLY_SCOPES : FULL_SCOPES;
   const modeLabel = readOnly ? "read-only" : "full access";
@@ -139,6 +142,7 @@ async function authenticate(readOnly: boolean) {
   }
 }
 
+/** Interactive auth-code + PKCE flow with loopback redirect; opens browser. */
 async function authenticateInteractive(readOnly: boolean) {
   const scopes = readOnly ? READ_ONLY_SCOPES : FULL_SCOPES;
   const modeLabel = readOnly ? "read-only" : "full access";
@@ -187,6 +191,7 @@ async function authenticateInteractive(readOnly: boolean) {
   }
 }
 
+/** Report persisted auth state (account, scope mode, token expiry) to stdout. */
 async function checkAuth() {
   try {
     const data = await fs.readFile(AUTH_INFO_PATH, "utf8");
@@ -237,6 +242,7 @@ async function checkAuth() {
   return false;
 }
 
+/** Remove persisted auth info + MSAL token cache files. */
 async function logout() {
   const CACHE_PATH = join(homedir(), ".teams-mcp-token-cache.json");
 
@@ -256,7 +262,7 @@ async function logout() {
   console.log("🔄 Run 'teams-mcp authenticate' (or '--interactive') to re-authenticate");
 }
 
-// MCP Server setup
+/** Boot MCP server over stdio, registering tool groups; warns on scope mismatch. */
 async function startMcpServer(readOnly: boolean) {
   // Create MCP server
   const server = new McpServer({
@@ -308,7 +314,7 @@ async function startMcpServer(readOnly: boolean) {
   console.error(`Microsoft Graph MCP Server started${readOnly ? " (read-only mode)" : ""}`);
 }
 
-// Main function to handle both CLI and MCP server modes
+/** CLI entry point — dispatches subcommands or starts the MCP server. */
 async function main() {
   const args = process.argv.slice(2);
   const command = args.find((arg) => arg !== "--read-only" && arg !== "--interactive");

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
 } from "@azure/msal-node";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { getAuthority, getClientId } from "./config.js";
 import { cachePlugin } from "./msal-cache.js";
 import { FULL_SCOPES, GraphService, READ_ONLY_SCOPES } from "./services/graph.js";
 import { registerAuthTools } from "./tools/auth.js";
@@ -18,15 +19,16 @@ import { registerSearchTools } from "./tools/search.js";
 import { registerTeamsTools } from "./tools/teams.js";
 import { registerUsersTools } from "./tools/users.js";
 
-// Microsoft Graph CLI app ID (default public client)
-const CLIENT_ID = "14d82eec-204b-4c2f-b7e8-296a70dab67e";
-const AUTHORITY = "https://login.microsoftonline.com/common";
-
 const AUTH_INFO_PATH = join(homedir(), ".msgraph-mcp-auth.json");
 
 /** Check whether CLI args contain --read-only. */
 function hasReadOnlyFlag(args: string[]): boolean {
   return args.includes("--read-only");
+}
+
+/** Check whether CLI args contain --interactive. */
+function hasInteractiveFlag(args: string[]): boolean {
+  return args.includes("--interactive");
 }
 
 /** Read the persisted auth info file (best-effort). */
@@ -39,22 +41,77 @@ async function readAuthInfo(): Promise<Record<string, unknown> | undefined> {
   }
 }
 
+async function saveAuthInfo(result: AuthenticationResult, clientId: string): Promise<void> {
+  const authInfo = {
+    clientId,
+    authenticated: true,
+    timestamp: new Date().toISOString(),
+    expiresAt: result.expiresOn?.toISOString(),
+    account: result.account?.username,
+    grantedScopes: result.scopes,
+  };
+  // 0o600 = owner-only; the file contains username + granted scopes (not the token itself,
+  // which lives in the MSAL cache file with its own 0o600 perms).
+  await fs.writeFile(AUTH_INFO_PATH, JSON.stringify(authInfo, null, 2), {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  try {
+    await fs.chmod(AUTH_INFO_PATH, 0o600);
+  } catch {
+    // chmod unsupported (Windows) — writeFile mode was best-effort
+  }
+}
+
+function reportAuthSuccess(
+  result: AuthenticationResult,
+  modeLabel: string,
+  flowLabel: string
+): void {
+  console.log("\n✅ Authentication successful!");
+  console.log(`👤 Signed in as: ${result.account?.username || "Unknown"}`);
+  console.log(`🔒 Mode: ${modeLabel}`);
+  console.log(`🔁 Flow: ${flowLabel}`);
+  console.log(`💾 Credentials saved to: ${AUTH_INFO_PATH}`);
+  console.log("🔄 Refresh token cached for automatic renewal");
+}
+
+function reportAuthError(error: unknown): never {
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  if (errorMessage.includes("AADSTS50020")) {
+    console.error("\n❌ Authentication failed: User account not in tenant");
+  } else if (errorMessage.includes("AADSTS65001")) {
+    console.error("\n❌ Authentication failed: Admin consent required");
+    console.error("   Grant admin consent for the required permissions in Azure Portal");
+  } else if (errorMessage.includes("AADSTS530032") || errorMessage.includes("AADSTS530003")) {
+    console.error("\n❌ Authentication failed: Blocked by Conditional Access");
+    console.error("   Try --interactive (browser-based) flow instead of device code:");
+    console.error("   teams-mcp authenticate --interactive");
+  } else {
+    console.error("\n❌ Authentication failed:", errorMessage);
+  }
+  process.exit(1);
+}
+
 // Authentication functions
 async function authenticate(readOnly: boolean) {
   const scopes = readOnly ? READ_ONLY_SCOPES : FULL_SCOPES;
   const modeLabel = readOnly ? "read-only" : "full access";
+  const clientId = getClientId();
 
   console.log("🔐 Microsoft Graph Authentication for MCP Server");
   console.log("=".repeat(50));
-  console.log(`Using Microsoft Graph CLI app (${modeLabel})`);
+  console.log(`Client ID: ${clientId}`);
+  console.log(`Authority: ${getAuthority()}`);
+  console.log(`Mode: ${modeLabel}`);
 
   try {
     console.log("\n📱 Using device code flow...");
 
     const msalConfig: Configuration = {
       auth: {
-        clientId: CLIENT_ID,
-        authority: AUTHORITY,
+        clientId,
+        authority: getAuthority(),
       },
       cache: {
         cachePlugin, // Use our custom file-based cache for refresh tokens
@@ -74,39 +131,59 @@ async function authenticate(readOnly: boolean) {
     });
 
     if (result) {
-      // Save authentication info (for quick status checks via CLI)
-      const authInfo = {
-        clientId: CLIENT_ID,
-        authenticated: true,
-        timestamp: new Date().toISOString(),
-        expiresAt: result.expiresOn?.toISOString(),
-        account: result.account?.username,
-        grantedScopes: result.scopes,
-      };
-
-      await fs.writeFile(AUTH_INFO_PATH, JSON.stringify(authInfo, null, 2));
-
-      console.log("\n✅ Authentication successful!");
-      console.log(`👤 Signed in as: ${result.account?.username || "Unknown"}`);
-      console.log(`🔒 Mode: ${modeLabel}`);
-      console.log(`💾 Credentials saved to: ${AUTH_INFO_PATH}`);
-      console.log("🔄 Refresh token cached for automatic renewal");
-      console.log("\n🚀 You can now use the MCP server in Cursor!");
-      console.log("   The server will automatically use these credentials.");
+      await saveAuthInfo(result, clientId);
+      reportAuthSuccess(result, modeLabel, "device code");
     }
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
+    reportAuthError(error);
+  }
+}
 
-    // Provide helpful error messages for common issues
-    if (errorMessage.includes("AADSTS50020")) {
-      console.error("\n❌ Authentication failed: User account not in tenant");
-    } else if (errorMessage.includes("AADSTS65001")) {
-      console.error("\n❌ Authentication failed: Admin consent required");
-      console.error("   Grant admin consent for the required permissions in Azure Portal");
-    } else {
-      console.error("\n❌ Authentication failed:", errorMessage);
+async function authenticateInteractive(readOnly: boolean) {
+  const scopes = readOnly ? READ_ONLY_SCOPES : FULL_SCOPES;
+  const modeLabel = readOnly ? "read-only" : "full access";
+  const clientId = getClientId();
+
+  console.log("🔐 Microsoft Graph Authentication for MCP Server");
+  console.log("=".repeat(50));
+  console.log(`Client ID: ${clientId}`);
+  console.log(`Authority: ${getAuthority()}`);
+  console.log(`Mode: ${modeLabel}`);
+
+  try {
+    console.log("\n🌐 Using interactive auth-code flow (browser + loopback)...");
+
+    const msalConfig: Configuration = {
+      auth: {
+        clientId,
+        authority: getAuthority(),
+      },
+      cache: {
+        cachePlugin,
+      },
+    };
+
+    const client = new PublicClientApplication(msalConfig);
+
+    const result = await client.acquireTokenInteractive({
+      scopes,
+      openBrowser: async (url) => {
+        console.log(`\n🌐 Opening browser to: ${url}`);
+        const { default: open } = await import("open");
+        await open(url);
+      },
+      successTemplate:
+        "<!DOCTYPE html><html><head><meta charset='utf-8'><title>Authentication successful</title></head><body style='font-family:sans-serif;text-align:center;padding:2em;'><h1 style='color:#2e7d32;'>Authentication successful</h1><p>You can close this tab and return to the terminal.</p></body></html>",
+      errorTemplate:
+        "<!DOCTYPE html><html><head><meta charset='utf-8'><title>Authentication failed</title></head><body style='font-family:sans-serif;text-align:center;padding:2em;'><h1 style='color:#c62828;'>Authentication failed</h1><p>Check the terminal for details.</p></body></html>",
+    });
+
+    if (result) {
+      await saveAuthInfo(result, clientId);
+      reportAuthSuccess(result, modeLabel, "interactive (auth code + PKCE)");
     }
-    process.exit(1);
+  } catch (error) {
+    reportAuthError(error);
   }
 }
 
@@ -176,7 +253,7 @@ async function logout() {
   }
 
   console.log("✅ Successfully logged out");
-  console.log("🔄 Run 'npx @floriscornel/teams-mcp@latest authenticate' to re-authenticate");
+  console.log("🔄 Run 'teams-mcp authenticate' (or '--interactive') to re-authenticate");
 }
 
 // MCP Server setup
@@ -234,15 +311,20 @@ async function startMcpServer(readOnly: boolean) {
 // Main function to handle both CLI and MCP server modes
 async function main() {
   const args = process.argv.slice(2);
-  const command = args.find((arg) => arg !== "--read-only");
+  const command = args.find((arg) => arg !== "--read-only" && arg !== "--interactive");
 
   const readOnly = hasReadOnlyFlag(args) || process.env.TEAMS_MCP_READ_ONLY === "true";
+  const interactive = hasInteractiveFlag(args);
 
   // CLI commands
   switch (command) {
     case "authenticate":
     case "auth":
-      await authenticate(readOnly);
+      if (interactive) {
+        await authenticateInteractive(readOnly);
+      } else {
+        await authenticate(readOnly);
+      }
       return;
     case "check":
       await checkAuth();
@@ -257,24 +339,23 @@ async function main() {
       console.log("");
       console.log("Usage:");
       console.log(
-        "  npx @floriscornel/teams-mcp@latest authenticate              # Authenticate with full scopes"
+        "  teams-mcp authenticate                 # Device-code flow (default)"
       );
       console.log(
-        "  npx @floriscornel/teams-mcp@latest authenticate --read-only  # Authenticate with read-only scopes"
+        "  teams-mcp authenticate --interactive   # Browser auth-code flow (PKCE, loopback)"
       );
       console.log(
-        "  npx @floriscornel/teams-mcp@latest check                     # Check authentication status"
+        "  teams-mcp authenticate --read-only     # Authenticate with read-only scopes"
       );
-      console.log(
-        "  npx @floriscornel/teams-mcp@latest logout                    # Clear authentication"
-      );
-      console.log(
-        "  npx @floriscornel/teams-mcp@latest                           # Start MCP server (default)"
-      );
+      console.log("  teams-mcp check                        # Check authentication status");
+      console.log("  teams-mcp logout                       # Clear authentication");
+      console.log("  teams-mcp                              # Start MCP server (default)");
       console.log("");
       console.log("Environment variables:");
-      console.log("  TEAMS_MCP_READ_ONLY=true  # Start MCP server in read-only mode");
-      console.log("  AUTH_TOKEN=<jwt>          # Use a pre-existing access token");
+      console.log("  TEAMS_MCP_READ_ONLY=true      # Start MCP server in read-only mode");
+      console.log("  TEAMS_MCP_CLIENT_ID=<guid>    # Override default Entra app (client) ID");
+      console.log("  TEAMS_MCP_AUTHORITY=<url>     # Override default authority");
+      console.log("  AUTH_TOKEN=<jwt>              # Use a pre-existing access token");
       return;
     case undefined:
       // No command = start MCP server

--- a/src/msal-cache.ts
+++ b/src/msal-cache.ts
@@ -26,7 +26,14 @@ export const cachePlugin: ICachePlugin = {
     if (cacheContext.cacheHasChanged) {
       try {
         const data = cacheContext.tokenCache.serialize();
-        await fs.writeFile(CACHE_PATH, data, "utf8");
+        // mode 0o600 = owner-only read/write; chmod is a no-op on Windows but
+        // narrows perms on POSIX systems where the cache contains refresh tokens.
+        await fs.writeFile(CACHE_PATH, data, { encoding: "utf8", mode: 0o600 });
+        try {
+          await fs.chmod(CACHE_PATH, 0o600);
+        } catch {
+          // chmod unsupported (Windows) — writeFile mode was a best-effort hint
+        }
       } catch (error) {
         console.error("Warning: Could not write token cache:", error);
       }

--- a/src/services/graph.ts
+++ b/src/services/graph.ts
@@ -1,9 +1,7 @@
 import { type AccountInfo, PublicClientApplication } from "@azure/msal-node";
 import { Client } from "@microsoft/microsoft-graph-client";
+import { getAuthority, getClientId } from "../config.js";
 import { cachePlugin } from "../msal-cache.js";
-
-const CLIENT_ID = "14d82eec-204b-4c2f-b7e8-296a70dab67e";
-const AUTHORITY = "https://login.microsoftonline.com/common";
 
 /** Scopes sufficient for read-only operations (no message sending, no file uploads). */
 export const READ_ONLY_SCOPES = [
@@ -84,8 +82,8 @@ export class GraphService {
       // Priority 2: MSAL with cached refresh token for automatic token renewal
       this.msalApp = new PublicClientApplication({
         auth: {
-          clientId: CLIENT_ID,
-          authority: AUTHORITY,
+          clientId: getClientId(),
+          authority: getAuthority(),
         },
         cache: {
           cachePlugin,
@@ -136,7 +134,7 @@ export class GraphService {
 
     if (!result) {
       throw new Error(
-        "Failed to acquire access token. Please re-authenticate: npx @floriscornel/teams-mcp@latest authenticate"
+        "Failed to acquire access token. Please re-authenticate: npx @floriscornel/teams-mcp@latest authenticate [--interactive]"
       );
     }
 
@@ -170,7 +168,7 @@ export class GraphService {
 
     if (!this.client) {
       throw new Error(
-        "Not authenticated. Please run the authentication CLI tool first: npx @floriscornel/teams-mcp@latest authenticate"
+        "Not authenticated. Please run the authentication CLI tool first: npx @floriscornel/teams-mcp@latest authenticate [--interactive]"
       );
     }
     return this.client;


### PR DESCRIPTION
## Why

On tenants that enable Microsoft's managed Conditional Access policy **"Block device code flow"** (default for tenants created after the 2025 security baseline rollout), the existing `authenticate` command fails with `AADSTS530032 / blocked by Conditional Access`. The device-code flow does not carry device identity, so CA cannot evaluate compliance and blocks it.

This PR adds an alternative, opt-in interactive flow that uses **OAuth auth-code + PKCE with a loopback redirect**. Because it goes through the browser, CA evaluates the user's normal session (device compliance, MFA, sign-in risk) and lets compliant users through.

## What

- **`authenticate --interactive`** — new flag on the existing CLI command.
Uses `PublicClientApplication.acquireTokenInteractive` (MSAL Node), opens
the default browser via [`open`](https://www.npmjs.com/package/open), and
listens on `http://localhost:<ephemeral-port>` for the redirect.
Falls back to clear error messages on `AADSTS65001`, `AADSTS50020`,
`AADSTS530032`, and nudges users toward `--interactive` when device-code
is blocked.
- **`src/config.ts`** — reads `TEAMS_MCP_CLIENT_ID` and `TEAMS_MCP_AUTHORITY`
from the environment, falling back to the existing Microsoft Graph CLI
client id (`14d82eec-...`) and `/common` authority. Tenants that require
the interactive flow need their own Entra app registration (since the
Graph CLI app does not have `http://localhost` registered as a redirect
URI in their tenant), so the client id and authority must be overridable.
- **`src/msal-cache.ts`** — write the token cache file with mode `0o600`
and `chmod` it after write (no-op on Windows). The cache contains refresh
tokens, so owner-only perms matter on shared POSIX hosts. Same hardening
applied to `.msgraph-mcp-auth.json` in `src/index.ts`.
- **`ENTRA_SETUP.md`** — step-by-step admin guide for creating the Entra
app registration (public client, `http://localhost` redirect, required
delegated Graph permissions, admin consent), plus a short "Path B" for
subsequent users in a tenant that already has the registration.
- **Deps**: `@azure/msal-node` (already a transitive dep, now direct) and
`open` (used to launch the browser).

## Backwards compatibility

- The default `authenticate` command is unchanged — still device-code flow, still the Graph CLI client id, still `/common` authority. With neither
`TEAMS_MCP_CLIENT_ID` nor `TEAMS_MCP_AUTHORITY` set, runtime behavior is byte-identical to upstream.
- `AUTH_TOKEN=<jwt>` env override is unchanged and still takes priority over the cached refresh token.
- Token cache file path (`~/.teams-mcp-token-cache.json`) and auth-info file path (`~/.msgraph-mcp-auth.json`) are unchanged.
- No breaking changes to the MCP tool surface.

## Usage

```bash
# Build
npm install && npm run build

# Authenticate (interactive, browser + loopback)
TEAMS_MCP_CLIENT_ID=<your-app-id> \
TEAMS_MCP_AUTHORITY=https://login.microsoftonline.com/<tenant-id> \
node dist/index.js authenticate --interactive

# Or with --read-only scopes
TEAMS_MCP_CLIENT_ID=... TEAMS_MCP_AUTHORITY=... \
node dist/index.js authenticate --interactive --read-only
```

See [`ENTRA_SETUP.md`](./ENTRA_SETUP.md) for the one-time tenant setup.

## Testing

- Unit: updated `src/__tests__/msal-cache.test.ts` covers the new mode/chmod paths; existing tests still pass (`npm test`).
- Manual: verified end-to-end against a tenant with **"Block device code flow"** CA policy enabled — device-code path fails with the new helpful error nudging toward `--interactive`; interactive path completes via browser and the MCP server picks up the cached refresh token on next start.

## Files changed

| File | Change |
|------|--------|
| `ENTRA_SETUP.md` | new — admin/user setup guide |
| `src/config.ts` | new — env-driven client id + authority |
| `src/index.ts` | `authenticate --interactive` command + better error mapping |
| `src/msal-cache.ts` | 0o600 perms on cache write |
| `src/__tests__/msal-cache.test.ts` | cover new perms paths |
| `src/services/graph.ts` | use `getClientId()` / `getAuthority()` from config |
| `package.json` / `package-lock.json` | add `@azure/msal-node`, `open` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive OAuth authentication via a new --interactive option and improved CLI help/messages.

* **Documentation**
  * Added a comprehensive Microsoft Entra ID setup guide covering onboarding, consent, configuration, and troubleshooting.

* **Security**
  * Token/cache persistence now uses owner-only file permissions and more robust handling of refresh tokens.

* **Usability**
  * Clearer success/error and logout guidance and support for configuring credentials via environment variables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/floriscornel/teams-mcp/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->