### PR TITLE
Encrypt token cache using OS credential store

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "@azure/identity": "^4.13.1",
     "@azure/identity-cache-persistence": "^1.2.0",
+    "@azure/msal-node-extensions": "^1.0.0",
     "@microsoft/microsoft-graph-client": "^3.0.7",
     "@microsoft/microsoft-graph-types": "^2.43.1",
     "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -45,11 +45,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/floriscornel/teams-mcp.git"
+    "url": "git+https://github.com/madubois08/teams-mcp.git"
   },
-  "homepage": "https://github.com/floriscornel/teams-mcp#readme",
+  "homepage": "https://github.com/madubois08/teams-mcp#readme",
   "bugs": {
-    "url": "https://github.com/floriscornel/teams-mcp/issues"
+    "url": "https://github.com/madubois08/teams-mcp/issues"
   },
   "dependencies": {
     "@azure/identity": "^4.13.1",

--- a/src/msal-cache.ts
+++ b/src/msal-cache.ts
@@ -3,19 +3,83 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { ICachePlugin, TokenCacheContext } from "@azure/msal-node";
 
-const CACHE_PATH = join(homedir(), ".teams-mcp-token-cache.json");
+export const CACHE_PATH = join(homedir(), ".teams-mcp-token-cache.json");
+const ENCRYPTED_CACHE_PATH = join(homedir(), ".teams-mcp-token-cache.dat");
 
 /**
- * Custom file-based cache plugin for MSAL Node
- * Stores tokens (including refresh tokens) in a JSON file
+ * Attempts to create an OS-level encrypted cache plugin using msal-node-extensions.
+ * - Windows  : DPAPI (lié à ton compte utilisateur Windows)
+ * - macOS    : Keychain
+ * - Linux    : libsecret
+ * Returns null if the extension is unavailable (fallback to plaintext).
+ */
+async function createEncryptedPlugin(): Promise<ICachePlugin | null> {
+  try {
+    const ext = await import("@azure/msal-node-extensions");
+
+    const platform = process.platform;
+    let persistence: unknown;
+
+    if (platform === "win32") {
+      const { FilePersistenceWithDataProtection, DataProtectionScope } = ext;
+      persistence = await FilePersistenceWithDataProtection.create(
+        ENCRYPTED_CACHE_PATH,
+        DataProtectionScope.CurrentUser,
+        ""
+      );
+    } else if (platform === "darwin") {
+      const { KeychainPersistence } = ext;
+      persistence = await KeychainPersistence.create(
+        ENCRYPTED_CACHE_PATH,
+        "teams-mcp",
+        "token-cache"
+      );
+    } else {
+      const { LibSecretPersistence } = ext;
+      persistence = await LibSecretPersistence.create(
+        ENCRYPTED_CACHE_PATH,
+        { schema: "teams-mcp-token-cache" }
+      );
+    }
+
+    const { PersistenceCachePlugin } = ext;
+    return new PersistenceCachePlugin(persistence as never);
+  } catch {
+    return null;
+  }
+}
+
+// Singleton — resolved once at startup
+let encryptedPluginPromise: Promise<ICachePlugin | null> | null = null;
+
+function getEncryptedPlugin(): Promise<ICachePlugin | null> {
+  if (!encryptedPluginPromise) {
+    encryptedPluginPromise = createEncryptedPlugin();
+  }
+  return encryptedPluginPromise;
+}
+
+/**
+ * ICachePlugin exposed to MSAL.
+ * Uses OS-encrypted storage when available; falls back to the plaintext
+ * JSON file with a one-time warning otherwise.
  */
 export const cachePlugin: ICachePlugin = {
   async beforeCacheAccess(cacheContext: TokenCacheContext): Promise<void> {
+    const plugin = await getEncryptedPlugin();
+    if (plugin) {
+      return plugin.beforeCacheAccess(cacheContext);
+    }
+
+    // Plaintext fallback
+    console.error(
+      "⚠️  teams-mcp: @azure/msal-node-extensions unavailable — " +
+      "token cache stored in plaintext at " + CACHE_PATH
+    );
     try {
       const data = await fs.readFile(CACHE_PATH, "utf8");
       cacheContext.tokenCache.deserialize(data);
     } catch (error) {
-      // File doesn't exist or is invalid - start with empty cache
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
         console.error("Warning: Could not read token cache:", error);
       }
@@ -23,6 +87,12 @@ export const cachePlugin: ICachePlugin = {
   },
 
   async afterCacheAccess(cacheContext: TokenCacheContext): Promise<void> {
+    const plugin = await getEncryptedPlugin();
+    if (plugin) {
+      return plugin.afterCacheAccess(cacheContext);
+    }
+
+    // Plaintext fallback
     if (cacheContext.cacheHasChanged) {
       try {
         const data = cacheContext.tokenCache.serialize();
@@ -33,5 +103,3 @@ export const cachePlugin: ICachePlugin = {
     }
   },
 };
-
-export { CACHE_PATH };

--- a/src/msal-cache.ts
+++ b/src/msal-cache.ts
@@ -8,7 +8,7 @@ const ENCRYPTED_CACHE_PATH = join(homedir(), ".teams-mcp-token-cache.dat");
 
 /**
  * Attempts to create an OS-level encrypted cache plugin using msal-node-extensions.
- * - Windows  : DPAPI (lié à ton compte utilisateur Windows)
+ * - Windows  : DPAPI (tied to your Windows user account)
  * - macOS    : Keychain
  * - Linux    : libsecret
  * Returns null if the extension is unavailable (fallback to plaintext).

--- a/src/msal-cache.ts
+++ b/src/msal-cache.ts
@@ -65,6 +65,7 @@ function getEncryptedPlugin(): Promise<ICachePlugin | null> {
  * Uses OS-encrypted storage when available; falls back to the plaintext
  * JSON file with a one-time warning otherwise.
  */
+let warnedAboutPlaintext = false;
 export const cachePlugin: ICachePlugin = {
   async beforeCacheAccess(cacheContext: TokenCacheContext): Promise<void> {
     const plugin = await getEncryptedPlugin();
@@ -72,11 +73,14 @@ export const cachePlugin: ICachePlugin = {
       return plugin.beforeCacheAccess(cacheContext);
     }
 
-    // Plaintext fallback
-    console.error(
-      "⚠️  teams-mcp: @azure/msal-node-extensions unavailable — " +
-      "token cache stored in plaintext at " + CACHE_PATH
-    );
+     // Plaintext fallback
+    if (!warnedAboutPlaintext) {
+      warnedAboutPlaintext = true;
+      console.error(
+        "⚠️  teams-mcp: `@azure/msal-node-extensions` unavailable — " +
+        "token cache stored in plaintext at " + CACHE_PATH
+      );
+    }
     try {
       const data = await fs.readFile(CACHE_PATH, "utf8");
       cacheContext.tokenCache.deserialize(data);

--- a/src/msal-cache.ts
+++ b/src/msal-cache.ts
@@ -38,7 +38,8 @@ async function createEncryptedPlugin(): Promise<ICachePlugin | null> {
       const { LibSecretPersistence } = ext;
       persistence = await LibSecretPersistence.create(
         ENCRYPTED_CACHE_PATH,
-        { schema: "teams-mcp-token-cache" }
+        "teams-mcp",
+        "token-cache"
       );
     }
 


### PR DESCRIPTION
feat: encrypt token cache using OS credential store (DPAPI on Windows, Keychain on macOS, libsecret on Linux)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Encrypted token cache persistence added, using OS-native secure storage on Windows, macOS, and Linux.
* **Chores**
  * Added dependency to enable OS-level secure credential storage.
  * Retains automatic plaintext cache fallback when secure storage is unavailable, preserving compatibility and existing tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->