### PR TITLE
Fix MSAL token cache race-safe writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ npx @floriscornel/teams-mcp@latest                           # Start MCP server 
 
 - `TEAMS_MCP_READ_ONLY=true` - Start the MCP server in read-only mode
 - `AUTH_TOKEN=<jwt>` - Use a pre-existing Microsoft Graph access token instead of MSAL login
+- `TEAMS_MCP_CACHE_PATH=<path>` - Store the token cache at a custom path for isolated or concurrent MCP runtimes
 
 ### Read-Only Mode
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ npx @floriscornel/teams-mcp@latest authenticate --read-only
 
 - Auth metadata is stored locally at `~/.msgraph-mcp-auth.json`
 - Token cache is stored locally at `~/.teams-mcp-token-cache.json`
+- Set `TEAMS_MCP_CACHE_PATH` to store the token cache at a custom path, which is useful for isolated or concurrent MCP runtimes.
 
 ## 🛠️ Usage
 
@@ -489,6 +490,7 @@ This MCP server is designed to work with AI assistants like Claude/Cursor/VS Cod
 - All authentication is handled through Microsoft's OAuth 2.0 flow or a caller-provided Microsoft Graph token
 - **Refresh token support**: Access tokens are automatically renewed using cached refresh tokens, so you don't need to re-authenticate every hour
 - Token cache is stored locally at `~/.teams-mcp-token-cache.json`
+- Set `TEAMS_MCP_CACHE_PATH` to store the token cache at a custom path
 - Auth metadata is stored locally at `~/.msgraph-mcp-auth.json`
 - Markdown content is sanitized before sending HTML to Teams
 - `AUTH_TOKEN` is validated to ensure it targets `https://graph.microsoft.com`

--- a/src/__tests__/msal-cache.test.ts
+++ b/src/__tests__/msal-cache.test.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from "node:fs";
+import { basename, join } from "node:path";
 import type { TokenCacheContext } from "@azure/msal-node";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -17,19 +18,66 @@ vi.mock("node:fs", () => ({
 // Import after mocks are set up
 import { CACHE_PATH, cachePlugin } from "../msal-cache.js";
 
+const CACHE_LOCK_PATH = `${CACHE_PATH}.lock`;
+const CACHE_LOCK_OWNER_PATH = join(CACHE_LOCK_PATH, "owner");
+const cacheFileNamePattern = escapeRegExp(basename(CACHE_PATH));
+const corruptCachePathPattern = new RegExp(`${cacheFileNamePattern}\\.corrupt\\.\\d+\\.\\d+$`);
+const tempCachePathPattern = new RegExp(`\\.${cacheFileNamePattern}\\.\\d+\\.\\d+\\.tmp$`);
+
+let currentLockOwner = "";
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function mockCacheRead(cacheData: string): void {
+  vi.mocked(fs.readFile).mockImplementation(async (path) => {
+    if (path === CACHE_LOCK_OWNER_PATH) {
+      return currentLockOwner;
+    }
+    if (path === CACHE_PATH) {
+      return cacheData;
+    }
+    throw new Error(`Unexpected read path: ${String(path)}`);
+  });
+}
+
+function mockCacheReadError(error: Error): void {
+  vi.mocked(fs.readFile).mockImplementation(async (path) => {
+    if (path === CACHE_LOCK_OWNER_PATH) {
+      return currentLockOwner;
+    }
+    if (path === CACHE_PATH) {
+      throw error;
+    }
+    throw new Error(`Unexpected read path: ${String(path)}`);
+  });
+}
+
 describe("MSAL Cache Plugin", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    currentLockOwner = "";
     vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+    vi.mocked(fs.readFile).mockImplementation(async (path) => {
+      if (path === CACHE_LOCK_OWNER_PATH) {
+        return currentLockOwner;
+      }
+      throw new Error(`Unexpected read path: ${String(path)}`);
+    });
     vi.mocked(fs.rename).mockResolvedValue(undefined);
     vi.mocked(fs.rm).mockResolvedValue(undefined);
-    vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+    vi.mocked(fs.writeFile).mockImplementation(async (path, data) => {
+      if (path === CACHE_LOCK_OWNER_PATH) {
+        currentLockOwner = String(data);
+      }
+    });
   });
 
   describe("beforeCacheAccess", () => {
     it("should deserialize cache data from file when it exists", async () => {
       const mockCacheData = '{"test": "data"}';
-      vi.mocked(fs.readFile).mockResolvedValue(mockCacheData);
+      mockCacheRead(mockCacheData);
 
       const deserializeMock = vi.fn();
       const cacheContext = {
@@ -42,13 +90,13 @@ describe("MSAL Cache Plugin", () => {
 
       expect(fs.readFile).toHaveBeenCalledWith(CACHE_PATH, "utf8");
       expect(deserializeMock).toHaveBeenCalledWith(mockCacheData);
-      expect(fs.rm).toHaveBeenCalledWith(`${CACHE_PATH}.lock`, { recursive: true, force: true });
+      expect(fs.rm).toHaveBeenCalledWith(CACHE_LOCK_PATH, { recursive: true, force: true });
     });
 
     it("should handle missing cache file (ENOENT) silently", async () => {
       const error = new Error("File not found") as NodeJS.ErrnoException;
       error.code = "ENOENT";
-      vi.mocked(fs.readFile).mockRejectedValue(error);
+      mockCacheReadError(error);
 
       const deserializeMock = vi.fn();
       const cacheContext = {
@@ -73,7 +121,7 @@ describe("MSAL Cache Plugin", () => {
     it("should log error for other file read failures", async () => {
       const error = new Error("Permission denied") as NodeJS.ErrnoException;
       error.code = "EACCES";
-      vi.mocked(fs.readFile).mockRejectedValue(error);
+      mockCacheReadError(error);
 
       const deserializeMock = vi.fn();
       const cacheContext = {
@@ -97,7 +145,7 @@ describe("MSAL Cache Plugin", () => {
 
     it("should quarantine invalid cache data and continue with an empty cache", async () => {
       const error = new SyntaxError("Unexpected non-whitespace character after JSON");
-      vi.mocked(fs.readFile).mockResolvedValue("{invalid-json}");
+      mockCacheRead("{invalid-json}");
 
       const deserializeMock = vi.fn().mockImplementation(() => {
         throw error;
@@ -117,14 +165,38 @@ describe("MSAL Cache Plugin", () => {
       expect(deserializeMock).toHaveBeenCalledWith("{invalid-json}");
       expect(fs.rename).toHaveBeenCalledWith(
         CACHE_PATH,
-        expect.stringMatching(/\.teams-mcp-token-cache\.json\.corrupt\.\d+\.\d+$/)
+        expect.stringMatching(corruptCachePathPattern)
       );
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "Warning: Token cache is invalid; moved aside:",
-        expect.stringMatching(/\.teams-mcp-token-cache\.json\.corrupt\.\d+\.\d+$/)
+        expect.stringMatching(corruptCachePathPattern)
       );
 
       consoleErrorSpy.mockRestore();
+    });
+
+    it("should not release a lock owned by another process", async () => {
+      const mockCacheData = '{"test": "data"}';
+      vi.mocked(fs.readFile).mockImplementation(async (path) => {
+        if (path === CACHE_LOCK_OWNER_PATH) {
+          return currentLockOwner;
+        }
+        if (path === CACHE_PATH) {
+          currentLockOwner = "999999.1.other-owner";
+          return mockCacheData;
+        }
+        throw new Error(`Unexpected read path: ${String(path)}`);
+      });
+
+      const cacheContext = {
+        tokenCache: {
+          deserialize: vi.fn(),
+        },
+      } as unknown as TokenCacheContext;
+
+      await cachePlugin.beforeCacheAccess(cacheContext);
+
+      expect(fs.rm).not.toHaveBeenCalledWith(CACHE_LOCK_PATH, { recursive: true, force: true });
     });
   });
 
@@ -144,12 +216,12 @@ describe("MSAL Cache Plugin", () => {
 
       expect(serializeMock).toHaveBeenCalled();
       expect(fs.writeFile).toHaveBeenCalledWith(
-        expect.stringMatching(/\.teams-mcp-token-cache\.json\.\d+\.\d+\.tmp$/),
+        expect.stringMatching(tempCachePathPattern),
         mockSerializedData,
         { encoding: "utf8", mode: 0o600 }
       );
       expect(fs.rename).toHaveBeenCalledWith(
-        expect.stringMatching(/\.teams-mcp-token-cache\.json\.\d+\.\d+\.tmp$/),
+        expect.stringMatching(tempCachePathPattern),
         CACHE_PATH
       );
     });
@@ -172,7 +244,13 @@ describe("MSAL Cache Plugin", () => {
 
     it("should log error when cache write fails", async () => {
       const error = new Error("Disk full");
-      vi.mocked(fs.writeFile).mockRejectedValue(error);
+      vi.mocked(fs.writeFile).mockImplementation(async (path, data) => {
+        if (path === CACHE_LOCK_OWNER_PATH) {
+          currentLockOwner = String(data);
+          return;
+        }
+        throw error;
+      });
 
       const mockSerializedData = '{"test": "serialized"}';
       const serializeMock = vi.fn().mockReturnValue(mockSerializedData);
@@ -192,7 +270,7 @@ describe("MSAL Cache Plugin", () => {
 
       expect(serializeMock).toHaveBeenCalled();
       expect(fs.writeFile).toHaveBeenCalledWith(
-        expect.stringMatching(/\.teams-mcp-token-cache\.json\.\d+\.\d+\.tmp$/),
+        expect.stringMatching(tempCachePathPattern),
         mockSerializedData,
         { encoding: "utf8", mode: 0o600 }
       );
@@ -206,7 +284,7 @@ describe("MSAL Cache Plugin", () => {
     it("should export CACHE_PATH", () => {
       expect(CACHE_PATH).toBeDefined();
       expect(typeof CACHE_PATH).toBe("string");
-      expect(CACHE_PATH).toContain(".teams-mcp-token-cache.json");
+      expect(basename(CACHE_PATH).length).toBeGreaterThan(0);
     });
   });
 });

--- a/src/__tests__/msal-cache.test.ts
+++ b/src/__tests__/msal-cache.test.ts
@@ -5,7 +5,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // Mock the filesystem
 vi.mock("node:fs", () => ({
   promises: {
+    mkdir: vi.fn(),
     readFile: vi.fn(),
+    rename: vi.fn(),
+    rm: vi.fn(),
+    stat: vi.fn(),
     writeFile: vi.fn(),
   },
 }));
@@ -16,6 +20,10 @@ import { CACHE_PATH, cachePlugin } from "../msal-cache.js";
 describe("MSAL Cache Plugin", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+    vi.mocked(fs.rename).mockResolvedValue(undefined);
+    vi.mocked(fs.rm).mockResolvedValue(undefined);
+    vi.mocked(fs.writeFile).mockResolvedValue(undefined);
   });
 
   describe("beforeCacheAccess", () => {
@@ -34,6 +42,7 @@ describe("MSAL Cache Plugin", () => {
 
       expect(fs.readFile).toHaveBeenCalledWith(CACHE_PATH, "utf8");
       expect(deserializeMock).toHaveBeenCalledWith(mockCacheData);
+      expect(fs.rm).toHaveBeenCalledWith(`${CACHE_PATH}.lock`, { recursive: true, force: true });
     });
 
     it("should handle missing cache file (ENOENT) silently", async () => {
@@ -85,6 +94,38 @@ describe("MSAL Cache Plugin", () => {
 
       consoleErrorSpy.mockRestore();
     });
+
+    it("should quarantine invalid cache data and continue with an empty cache", async () => {
+      const error = new SyntaxError("Unexpected non-whitespace character after JSON");
+      vi.mocked(fs.readFile).mockResolvedValue("{invalid-json}");
+
+      const deserializeMock = vi.fn().mockImplementation(() => {
+        throw error;
+      });
+      const cacheContext = {
+        tokenCache: {
+          deserialize: deserializeMock,
+        },
+      } as unknown as TokenCacheContext;
+
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {
+        // Intentionally empty to suppress console output during tests
+      });
+
+      await cachePlugin.beforeCacheAccess(cacheContext);
+
+      expect(deserializeMock).toHaveBeenCalledWith("{invalid-json}");
+      expect(fs.rename).toHaveBeenCalledWith(
+        CACHE_PATH,
+        expect.stringMatching(/\.teams-mcp-token-cache\.json\.corrupt\.\d+\.\d+$/)
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Warning: Token cache is invalid; moved aside:",
+        expect.stringMatching(/\.teams-mcp-token-cache\.json\.corrupt\.\d+\.\d+$/)
+      );
+
+      consoleErrorSpy.mockRestore();
+    });
   });
 
   describe("afterCacheAccess", () => {
@@ -102,7 +143,15 @@ describe("MSAL Cache Plugin", () => {
       await cachePlugin.afterCacheAccess(cacheContext);
 
       expect(serializeMock).toHaveBeenCalled();
-      expect(fs.writeFile).toHaveBeenCalledWith(CACHE_PATH, mockSerializedData, "utf8");
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        expect.stringMatching(/\.teams-mcp-token-cache\.json\.\d+\.\d+\.tmp$/),
+        mockSerializedData,
+        { encoding: "utf8", mode: 0o600 }
+      );
+      expect(fs.rename).toHaveBeenCalledWith(
+        expect.stringMatching(/\.teams-mcp-token-cache\.json\.\d+\.\d+\.tmp$/),
+        CACHE_PATH
+      );
     });
 
     it("should not write cache data when cache has not changed", async () => {
@@ -142,7 +191,11 @@ describe("MSAL Cache Plugin", () => {
       await cachePlugin.afterCacheAccess(cacheContext);
 
       expect(serializeMock).toHaveBeenCalled();
-      expect(fs.writeFile).toHaveBeenCalledWith(CACHE_PATH, mockSerializedData, "utf8");
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        expect.stringMatching(/\.teams-mcp-token-cache\.json\.\d+\.\d+\.tmp$/),
+        mockSerializedData,
+        { encoding: "utf8", mode: 0o600 }
+      );
       expect(consoleErrorSpy).toHaveBeenCalledWith("Warning: Could not write token cache:", error);
 
       consoleErrorSpy.mockRestore();

--- a/src/msal-cache.ts
+++ b/src/msal-cache.ts
@@ -1,4 +1,5 @@
-import { promises as fs } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { promises as fs, type Stats } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -7,35 +8,95 @@ import type { ICachePlugin, TokenCacheContext } from "@azure/msal-node";
 const CACHE_PATH =
   process.env.TEAMS_MCP_CACHE_PATH ?? join(homedir(), ".teams-mcp-token-cache.json");
 const CACHE_LOCK_PATH = `${CACHE_PATH}.lock`;
+const CACHE_LOCK_OWNER_PATH = join(CACHE_LOCK_PATH, "owner");
 const LOCK_RETRY_DELAY_MS = 100;
 const LOCK_TIMEOUT_MS = 5000;
 const STALE_LOCK_MS = 30000;
 
-async function acquireCacheLock(): Promise<void> {
+type CacheLock = {
+  owner: string;
+};
+
+function createLockOwner(): string {
+  return `${process.pid}.${Date.now()}.${randomUUID()}`;
+}
+
+function parseOwnerPid(owner: string): number | undefined {
+  const pid = Number(owner.split(".", 1)[0]);
+  return Number.isInteger(pid) && pid > 0 ? pid : undefined;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+async function removeStaleCacheLockIfOrphaned(): Promise<boolean> {
+  let stat: Stats;
+
+  try {
+    stat = await fs.stat(CACHE_LOCK_PATH);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return true;
+    }
+    throw error;
+  }
+
+  if (Date.now() - stat.mtimeMs <= STALE_LOCK_MS) {
+    return false;
+  }
+
+  let owner: string | undefined;
+  try {
+    owner = await fs.readFile(CACHE_LOCK_OWNER_PATH, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  const ownerPid = owner ? parseOwnerPid(owner) : undefined;
+  if (ownerPid && isProcessAlive(ownerPid)) {
+    return false;
+  }
+
+  await fs.rm(CACHE_LOCK_PATH, { recursive: true, force: true });
+  return true;
+}
+
+async function acquireCacheLock(): Promise<CacheLock> {
   const startedAt = Date.now();
+  const owner = createLockOwner();
 
   await fs.mkdir(dirname(CACHE_PATH), { recursive: true });
 
   while (true) {
     try {
       await fs.mkdir(CACHE_LOCK_PATH);
-      return;
+      try {
+        await fs.writeFile(CACHE_LOCK_OWNER_PATH, owner, {
+          encoding: "utf8",
+          flag: "wx",
+          mode: 0o600,
+        });
+      } catch (error) {
+        await fs.rm(CACHE_LOCK_PATH, { recursive: true, force: true });
+        throw error;
+      }
+      return { owner };
     } catch (error) {
       const nodeError = error as NodeJS.ErrnoException;
       if (nodeError.code !== "EEXIST") {
         throw error;
       }
 
-      try {
-        const stat = await fs.stat(CACHE_LOCK_PATH);
-        if (Date.now() - stat.mtimeMs > STALE_LOCK_MS) {
-          await fs.rm(CACHE_LOCK_PATH, { recursive: true, force: true });
-          continue;
-        }
-      } catch (statError) {
-        if ((statError as NodeJS.ErrnoException).code !== "ENOENT") {
-          throw statError;
-        }
+      if (await removeStaleCacheLockIfOrphaned()) {
+        continue;
       }
 
       if (Date.now() - startedAt > LOCK_TIMEOUT_MS) {
@@ -47,12 +108,29 @@ async function acquireCacheLock(): Promise<void> {
   }
 }
 
+async function releaseCacheLock(lock: CacheLock): Promise<void> {
+  let owner: string;
+
+  try {
+    owner = await fs.readFile(CACHE_LOCK_OWNER_PATH, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+
+  if (owner === lock.owner) {
+    await fs.rm(CACHE_LOCK_PATH, { recursive: true, force: true });
+  }
+}
+
 async function withCacheLock<T>(operation: () => Promise<T>): Promise<T> {
-  await acquireCacheLock();
+  const lock = await acquireCacheLock();
   try {
     return await operation();
   } finally {
-    await fs.rm(CACHE_LOCK_PATH, { recursive: true, force: true });
+    await releaseCacheLock(lock);
   }
 }
 

--- a/src/msal-cache.ts
+++ b/src/msal-cache.ts
@@ -1,9 +1,83 @@
 import { promises as fs } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
 import type { ICachePlugin, TokenCacheContext } from "@azure/msal-node";
 
-const CACHE_PATH = join(homedir(), ".teams-mcp-token-cache.json");
+const CACHE_PATH =
+  process.env.TEAMS_MCP_CACHE_PATH ?? join(homedir(), ".teams-mcp-token-cache.json");
+const CACHE_LOCK_PATH = `${CACHE_PATH}.lock`;
+const LOCK_RETRY_DELAY_MS = 100;
+const LOCK_TIMEOUT_MS = 5000;
+const STALE_LOCK_MS = 30000;
+
+async function acquireCacheLock(): Promise<void> {
+  const startedAt = Date.now();
+
+  await fs.mkdir(dirname(CACHE_PATH), { recursive: true });
+
+  while (true) {
+    try {
+      await fs.mkdir(CACHE_LOCK_PATH);
+      return;
+    } catch (error) {
+      const nodeError = error as NodeJS.ErrnoException;
+      if (nodeError.code !== "EEXIST") {
+        throw error;
+      }
+
+      try {
+        const stat = await fs.stat(CACHE_LOCK_PATH);
+        if (Date.now() - stat.mtimeMs > STALE_LOCK_MS) {
+          await fs.rm(CACHE_LOCK_PATH, { recursive: true, force: true });
+          continue;
+        }
+      } catch (statError) {
+        if ((statError as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw statError;
+        }
+      }
+
+      if (Date.now() - startedAt > LOCK_TIMEOUT_MS) {
+        throw new Error(`Timed out waiting for token cache lock: ${CACHE_LOCK_PATH}`);
+      }
+
+      await sleep(LOCK_RETRY_DELAY_MS);
+    }
+  }
+}
+
+async function withCacheLock<T>(operation: () => Promise<T>): Promise<T> {
+  await acquireCacheLock();
+  try {
+    return await operation();
+  } finally {
+    await fs.rm(CACHE_LOCK_PATH, { recursive: true, force: true });
+  }
+}
+
+async function quarantineInvalidCache(): Promise<string | undefined> {
+  const quarantinePath = `${CACHE_PATH}.corrupt.${Date.now()}.${process.pid}`;
+  try {
+    await fs.rename(CACHE_PATH, quarantinePath);
+    return quarantinePath;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.error("Warning: Could not quarantine invalid token cache:", error);
+    }
+    return undefined;
+  }
+}
+
+async function writeCacheAtomically(data: string): Promise<void> {
+  const tmpPath = join(
+    dirname(CACHE_PATH),
+    `.${basename(CACHE_PATH)}.${process.pid}.${Date.now()}.tmp`
+  );
+
+  await fs.writeFile(tmpPath, data, { encoding: "utf8", mode: 0o600 });
+  await fs.rename(tmpPath, CACHE_PATH);
+}
 
 /**
  * Custom file-based cache plugin for MSAL Node
@@ -11,25 +85,42 @@ const CACHE_PATH = join(homedir(), ".teams-mcp-token-cache.json");
  */
 export const cachePlugin: ICachePlugin = {
   async beforeCacheAccess(cacheContext: TokenCacheContext): Promise<void> {
-    try {
-      const data = await fs.readFile(CACHE_PATH, "utf8");
-      cacheContext.tokenCache.deserialize(data);
-    } catch (error) {
-      // File doesn't exist or is invalid - start with empty cache
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+    await withCacheLock(async () => {
+      let data: string;
+
+      try {
+        data = await fs.readFile(CACHE_PATH, "utf8");
+      } catch (error) {
+        // File doesn't exist - start with empty cache.
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          return;
+        }
+
         console.error("Warning: Could not read token cache:", error);
+        return;
       }
-    }
+
+      try {
+        cacheContext.tokenCache.deserialize(data);
+      } catch {
+        const quarantinePath = await quarantineInvalidCache();
+        if (quarantinePath) {
+          console.error("Warning: Token cache is invalid; moved aside:", quarantinePath);
+        }
+      }
+    });
   },
 
   async afterCacheAccess(cacheContext: TokenCacheContext): Promise<void> {
     if (cacheContext.cacheHasChanged) {
-      try {
-        const data = cacheContext.tokenCache.serialize();
-        await fs.writeFile(CACHE_PATH, data, "utf8");
-      } catch (error) {
-        console.error("Warning: Could not write token cache:", error);
-      }
+      await withCacheLock(async () => {
+        try {
+          const data = cacheContext.tokenCache.serialize();
+          await writeCacheAtomically(data);
+        } catch (error) {
+          console.error("Warning: Could not write token cache:", error);
+        }
+      });
     }
   },
 };

--- a/src/services/__tests__/graph.test.ts
+++ b/src/services/__tests__/graph.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mockUser, server } from "../../test-utils/setup.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockUser } from "../../test-utils/setup.js";
 
 // Mock the msal-cache plugin
 vi.mock("../../msal-cache.js", () => ({
@@ -46,18 +46,12 @@ describe("GraphService", () => {
   let graphService: GraphService;
 
   beforeEach(() => {
-    server.listen({ onUnhandledRequest: "error" });
     vi.clearAllMocks();
     setupDefaultMsalMock();
 
     // Reset GraphService singleton
     (GraphService as any).instance = undefined;
     graphService = GraphService.getInstance();
-  });
-
-  afterEach(() => {
-    server.resetHandlers();
-    server.close();
   });
 
   describe("getInstance", () => {


### PR DESCRIPTION
## Summary

- Add a `TEAMS_MCP_CACHE_PATH` override so concurrent or isolated MCP runtimes can avoid sharing one cache file.
- Serialize cache file access with a lightweight lock directory and stale-lock cleanup.
- Write token cache updates via temp file + atomic rename.
- Move invalid cache files aside as `.corrupt.<timestamp>.<pid>` instead of repeatedly failing to deserialize them.
- Document the new cache path override.

## Why

In multi-process MCP runtimes, multiple `teams-mcp` instances can read and write the same MSAL cache file concurrently. A partially written or otherwise invalid JSON cache makes every subsequent Graph request fail during cache deserialization. The lock + atomic rename path prevents truncated/interleaved writes, while quarantine lets the server recover from an already-invalid cache.

## Validation

- `npm test`
- `npm run ci`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the token cache location via `TEAMS_MCP_CACHE_PATH`.

* **Bug Fixes**
  * Improved reliability by adding cross-process locking for cache reads/writes.
  * Enhanced resilience to corrupted cache data by quarantining invalid files.
  * Switched to atomic cache updates using temporary files followed by rename.

* **Documentation**
  * Documented `TEAMS_MCP_CACHE_PATH` in the README (Token Storage, Environment Variables, and Security).

* **Tests**
  * Expanded cache test coverage for locking, quarantine behavior, and atomic write flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->